### PR TITLE
changed Maven group ID to `com.expediagroup.apiary`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [TBA] - TBD
+### Changed
+- Maven group ID is now `com.expediagroup.apiary` (was `com.expedia.apiary`).
+
 ## [2.0.0] - 2019-04-08
 ### Changed
 - `MessageReader.read()` now returns `MessageEvent`, wrapping `ListenerEvent` and `MessageProperty`.

--- a/apiary-gluesync-listener/pom.xml
+++ b/apiary-gluesync-listener/pom.xml
@@ -2,9 +2,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.expedia.apiary</groupId>
+    <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-gluesync-listener</artifactId>
@@ -79,7 +79,7 @@
               <artifactSet>
                 <includes>
                   <include>com.amazonaws:*</include>
-                  <include>com.expedia.apiary:*</include>
+                  <include>com.expediagroup.apiary:*</include>
                   <include>org.apache.httpcomponents:*</include>
                 </includes>
               </artifactSet>

--- a/apiary-metastore-auth/pom.xml
+++ b/apiary-metastore-auth/pom.xml
@@ -2,9 +2,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.expedia.apiary</groupId>
+    <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-auth</artifactId>

--- a/apiary-metastore-listener/pom.xml
+++ b/apiary-metastore-listener/pom.xml
@@ -2,9 +2,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.expedia.apiary</groupId>
+    <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-listener</artifactId>
@@ -84,7 +84,7 @@
               <artifactSet>
                 <includes>
                   <include>com.amazonaws:*</include>
-                  <include>com.expedia.apiary:*</include>
+                  <include>com.expediagroup.apiary:*</include>
                   <include>com.fasterxml.jackson.*:*</include>
                   <include>com.tdunning:json</include>
                   <include>org.apache.httpcomponents:*</include>

--- a/apiary-metastore-metrics/pom.xml
+++ b/apiary-metastore-metrics/pom.xml
@@ -2,9 +2,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.expedia.apiary</groupId>
+    <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-metrics</artifactId>
@@ -77,7 +77,7 @@
               <artifactSet>
                 <includes>
                   <include>com.amazonaws:*</include>
-                  <include>com.expedia.apiary:*</include>
+                  <include>com.expediagroup.apiary:*</include>
                 </includes>
               </artifactSet>
               <relocations>

--- a/apiary-ranger-metastore-plugin/pom.xml
+++ b/apiary-ranger-metastore-plugin/pom.xml
@@ -2,9 +2,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.expedia.apiary</groupId>
+    <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-ranger-metastore-plugin</artifactId>
@@ -115,7 +115,7 @@
               <shadedClassifierName>all</shadedClassifierName>
               <artifactSet>
                 <includes>
-                  <include>com.expedia.apiary:*</include>
+                  <include>com.expediagroup.apiary:*</include>
                   <include>org.apache.ranger:*</include>
                   <include>org.apache.solr:*</include>
                   <include>org.apache.httpcomponents:*</include>

--- a/apiary-receivers/apiary-receiver-common/pom.xml
+++ b/apiary-receivers/apiary-receiver-common/pom.xml
@@ -2,9 +2,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.expedia.apiary</groupId>
+    <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-receivers-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-receiver-common</artifactId>

--- a/apiary-receivers/apiary-receiver-sqs/pom.xml
+++ b/apiary-receivers/apiary-receiver-sqs/pom.xml
@@ -2,9 +2,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.expedia.apiary</groupId>
+    <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-receivers-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-receiver-sqs</artifactId>
@@ -19,7 +19,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.expedia.apiary</groupId>
+      <groupId>com.expediagroup.apiary</groupId>
       <artifactId>apiary-receiver-common</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/apiary-receivers/pom.xml
+++ b/apiary-receivers/pom.xml
@@ -2,17 +2,17 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.expedia.apiary</groupId>
+    <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-receivers-parent</artifactId>
   <packaging>pom</packaging>
 
   <modules>
-    <module>apiary-receiver-sqs</module>
     <module>apiary-receiver-common</module>
+    <module>apiary-receiver-sqs</module>
   </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,10 +8,10 @@
     <version>2.3.5</version>
   </parent>
 
-  <groupId>com.expedia.apiary</groupId>
+  <groupId>com.expediagroup.apiary</groupId>
   <artifactId>apiary-extensions-parent</artifactId>
   <description>Various extensions to Apiary that provide additional, optional functionality</description>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apiary Extensions Parent</name>
   <inceptionYear>2018</inceptionYear>


### PR DESCRIPTION
I need to change the Maven Group ID in order for the CICD pipeline to be able to produce artifacts as it is now using a user which has push access to `com.expediagroup` not `com.expedia`.

I plan to do this in two stages. The first stage (in this PR) just changes the group ID in the pom.xml files but leaves the Java code packaged in the `com.expedia.apiary` package. Once I can publish SNAPSHOTs using the CICD pipeline with this new group ID then I will raise another PR which repackages all the Java code so that the base package matches the groupId. 

These two changes will be bundled into a 3.0.0 version of apiary-extensions. Once that's released I'll change all the downstream projects to pull in this version and update any references to Java classnames.