### PR TITLE
hotels-oss-parent version updated to 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 - Maven group ID is now `com.expediagroup.apiary` (was `com.expedia.apiary`).
 - All Java classes moved to `com.expediagroup.apiary` (was `com.expedia.apiary`).
+- `hotels-oss-parent` version updated to 4.0.1 (was 2.3.5).
 
 ## [2.0.0] - 2019-04-08
 ### Changed

--- a/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/ApiaryGluePreEventListener.java
+++ b/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/ApiaryGluePreEventListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/ApiaryGlueSync.java
+++ b/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/ApiaryGlueSync.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/ApiaryGlueSyncTest.java
+++ b/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/ApiaryGlueSyncTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-gluesync-listener/src/test/resources/log4j2.xml
+++ b/apiary-gluesync-listener/src/test/resources/log4j2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2018-2019 Expedia Inc.
+  Copyright (C) 2018-2019 Expedia, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/apiary-metastore-auth/src/main/java/com/expediagroup/apiary/extensions/readonlyauth/listener/ApiaryReadOnlyAuthPreEventListener.java
+++ b/apiary-metastore-auth/src/main/java/com/expediagroup/apiary/extensions/readonlyauth/listener/ApiaryReadOnlyAuthPreEventListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-metastore-auth/src/test/java/com/expediagroup/apiary/extensions/readonlyauth/listener/ApiaryReadOnlyAuthPreEventListenerTest.java
+++ b/apiary-metastore-auth/src/test/java/com/expediagroup/apiary/extensions/readonlyauth/listener/ApiaryReadOnlyAuthPreEventListenerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/metastore/listener/ApiarySnsListener.java
+++ b/apiary-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/metastore/listener/ApiarySnsListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/metastore/listener/EventType.java
+++ b/apiary-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/metastore/listener/EventType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/metastore/listener/MessageAttributeDataType.java
+++ b/apiary-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/metastore/listener/MessageAttributeDataType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/metastore/listener/MessageAttributeKey.java
+++ b/apiary-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/metastore/listener/MessageAttributeKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-metastore-listener/src/test/java/com/expediagroup/apiary/extensions/metastore/listener/ApiarySnsListenerTest.java
+++ b/apiary-metastore-listener/src/test/java/com/expediagroup/apiary/extensions/metastore/listener/ApiarySnsListenerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-metastore-listener/src/test/resources/log4j2.xml
+++ b/apiary-metastore-listener/src/test/resources/log4j2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2018-2019 Expedia Inc.
+  Copyright (C) 2018-2019 Expedia, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/apiary-metastore-metrics/src/main/java/com/expediagroup/apiary/extensions/metastore/metrics/CloudwatchReporter.java
+++ b/apiary-metastore-metrics/src/main/java/com/expediagroup/apiary/extensions/metastore/metrics/CloudwatchReporter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-metastore-metrics/src/main/java/com/expediagroup/apiary/extensions/metastore/metrics/CodahaleMetrics.java
+++ b/apiary-metastore-metrics/src/main/java/com/expediagroup/apiary/extensions/metastore/metrics/CodahaleMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-metastore-metrics/src/test/java/com/expediagroup/apiary/extensions/metastore/metrics/CodahaleMetricsTest.java
+++ b/apiary-metastore-metrics/src/test/java/com/expediagroup/apiary/extensions/metastore/metrics/CodahaleMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-metastore-metrics/src/test/java/com/expediagroup/apiary/extensions/metastore/metrics/MetricsTestUtils.java
+++ b/apiary-metastore-metrics/src/test/java/com/expediagroup/apiary/extensions/metastore/metrics/MetricsTestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-ranger-metastore-plugin/src/main/java/com/expediagroup/apiary/extensions/rangerauth/listener/ApiaryRangerAuthPreEventListener.java
+++ b/apiary-ranger-metastore-plugin/src/main/java/com/expediagroup/apiary/extensions/rangerauth/listener/ApiaryRangerAuthPreEventListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-ranger-metastore-plugin/src/test/java/com/expediagroup/apiary/extensions/rangerauth/listener/ApiaryRangerAuthPreEventListenerTest.java
+++ b/apiary-ranger-metastore-plugin/src/test/java/com/expediagroup/apiary/extensions/rangerauth/listener/ApiaryRangerAuthPreEventListenerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-ranger-metastore-plugin/src/test/java/com/expediagroup/apiary/extensions/rangerauth/listener/RangerAdminClientImpl.java
+++ b/apiary-ranger-metastore-plugin/src/test/java/com/expediagroup/apiary/extensions/rangerauth/listener/RangerAdminClientImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-ranger-metastore-plugin/src/test/resources/ranger-hive-security.xml
+++ b/apiary-ranger-metastore-plugin/src/test/resources/ranger-hive-security.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  Copyright (C) 2018-2019 Expedia Inc.
+  Copyright (C) 2018-2019 Expedia, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/error/ApiaryReceiverException.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/error/ApiaryReceiverException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/error/SerDeException.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/error/SerDeException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/AddPartitionEvent.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/AddPartitionEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/AlterPartitionEvent.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/AlterPartitionEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/AlterTableEvent.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/AlterTableEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/CreateTableEvent.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/CreateTableEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/DropPartitionEvent.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/DropPartitionEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/DropTableEvent.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/DropTableEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/EventType.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/EventType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/InsertTableEvent.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/InsertTableEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/ListenerEvent.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/event/ListenerEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/messaging/JsonMetaStoreEventDeserializer.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/messaging/JsonMetaStoreEventDeserializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/messaging/MessageDeserializer.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/messaging/MessageDeserializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/messaging/MessageEvent.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/messaging/MessageEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/messaging/MessageProperty.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/messaging/MessageProperty.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/messaging/MessageReader.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/messaging/MessageReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/messaging/MetaStoreEventDeserializer.java
+++ b/apiary-receivers/apiary-receiver-common/src/main/java/com/expediagroup/apiary/extensions/receiver/common/messaging/MetaStoreEventDeserializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/test/java/com/expediagroup/apiary/extensions/receiver/common/event/EventTypeTest.java
+++ b/apiary-receivers/apiary-receiver-common/src/test/java/com/expediagroup/apiary/extensions/receiver/common/event/EventTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-common/src/test/java/com/expediagroup/apiary/extensions/receiver/common/messaging/JsonMetaStoreEventDeserializerTest.java
+++ b/apiary-receivers/apiary-receiver-common/src/test/java/com/expediagroup/apiary/extensions/receiver/common/messaging/JsonMetaStoreEventDeserializerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-sqs/src/main/java/com/expediagroup/apiary/extensions/receiver/sqs/messaging/DefaultSqsMessageDeserializer.java
+++ b/apiary-receivers/apiary-receiver-sqs/src/main/java/com/expediagroup/apiary/extensions/receiver/sqs/messaging/DefaultSqsMessageDeserializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-sqs/src/main/java/com/expediagroup/apiary/extensions/receiver/sqs/messaging/SqsMessage.java
+++ b/apiary-receivers/apiary-receiver-sqs/src/main/java/com/expediagroup/apiary/extensions/receiver/sqs/messaging/SqsMessage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-sqs/src/main/java/com/expediagroup/apiary/extensions/receiver/sqs/messaging/SqsMessageProperty.java
+++ b/apiary-receivers/apiary-receiver-sqs/src/main/java/com/expediagroup/apiary/extensions/receiver/sqs/messaging/SqsMessageProperty.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-sqs/src/main/java/com/expediagroup/apiary/extensions/receiver/sqs/messaging/SqsMessageReader.java
+++ b/apiary-receivers/apiary-receiver-sqs/src/main/java/com/expediagroup/apiary/extensions/receiver/sqs/messaging/SqsMessageReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-sqs/src/test/java/com/expediagroup/apiary/extensions/receiver/sqs/DefaultSqsMessageDeserializerTest.java
+++ b/apiary-receivers/apiary-receiver-sqs/src/test/java/com/expediagroup/apiary/extensions/receiver/sqs/DefaultSqsMessageDeserializerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-receivers/apiary-receiver-sqs/src/test/java/com/expediagroup/apiary/extensions/receiver/sqs/SqsMessageReaderTest.java
+++ b/apiary-receivers/apiary-receiver-sqs/src/test/java/com/expediagroup/apiary/extensions/receiver/sqs/SqsMessageReaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia Inc.
+ * Copyright (C) 2018-2019 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>hotels-oss-parent</artifactId>
-    <version>2.3.5</version>
+    <version>4.0.1</version>
   </parent>
 
   <groupId>com.expediagroup.apiary</groupId>
@@ -25,7 +25,6 @@
 
   <properties>
     <aws-java-sdk.version>1.11.333</aws-java-sdk.version>
-    <jdk.version>1.8</jdk.version>
     <hadoop.version>2.7.1</hadoop.version>
     <hive.version>2.3.3</hive.version>
     <ranger.version>1.1.0</ranger.version>


### PR DESCRIPTION
The new parent pom also triggers a license header change which introduces a "," in the copyright line.