### PR TITLE
Fix for apiary-metastore-listener table parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## TBD
+### Fixed
+- `apiary-metastore-listener` now serialises metastore table properties as a Map instead of a String. 
+
 ## [3.0.0] - 2019-04-12
 ### Changed
 - Maven group ID is now `com.expediagroup.apiary` (was `com.expedia.apiary`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## TBD
 ### Fixed
-- `apiary-metastore-listener` now serialises metastore table properties as a Map instead of a String. 
+- `apiary-metastore-listener` now serializes metastore table properties as a Map instead of a String. 
 
 ## [3.0.0] - 2019-04-12
 ### Changed

--- a/apiary-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/metastore/listener/ApiarySnsListener.java
+++ b/apiary-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/metastore/listener/ApiarySnsListener.java
@@ -158,7 +158,10 @@ public class ApiarySnsListener extends MetaStoreEventListener {
     json.put("tableLocation", table.getSd().getLocation());
 
     if (tableParamFilterPattern != null) {
-      json.put("tableParameters", getFilteredParams(table.getParameters()));
+      Map<String, String> filteredParams = getFilteredParams(table.getParameters());
+      JSONObject tableParameters = new JSONObject();
+      filteredParams.forEach(tableParameters::put);
+      json.put("tableParameters", tableParameters);
     }
 
     if (oldtable != null) {

--- a/apiary-metastore-listener/src/test/java/com/expediagroup/apiary/extensions/metastore/listener/ApiarySnsListenerTest.java
+++ b/apiary-metastore-listener/src/test/java/com/expediagroup/apiary/extensions/metastore/listener/ApiarySnsListenerTest.java
@@ -140,7 +140,7 @@ public class ApiarySnsListenerTest {
             + PROTOCOL_VERSION
             + "\",\"eventType\":\""
             + EventType.CREATE_TABLE.toString()
-            + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":\"{MY_VAR_TWO=5, MY_VAR_ONE=true}\"}"));
+            + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":{\"MY_VAR_TWO\":\"5\",\"MY_VAR_ONE\":\"true\"}}"));
 
     verifyMessageAttributes(publishRequest,  EventType.CREATE_TABLE.toString());
   }
@@ -159,7 +159,7 @@ public class ApiarySnsListenerTest {
         + PROTOCOL_VERSION
         + "\",\"eventType\":\""
         + EventType.CREATE_TABLE.toString()
-        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":\"{}\"}"));
+        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":{}}"));
   }
 
   @Test
@@ -176,7 +176,7 @@ public class ApiarySnsListenerTest {
         + PROTOCOL_VERSION
         + "\",\"eventType\":\""
         + EventType.CREATE_TABLE.toString()
-        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":\"{}\"}"));
+        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":{}}"));
   }
 
   @Test
@@ -214,7 +214,7 @@ public class ApiarySnsListenerTest {
         + PROTOCOL_VERSION
         + "\",\"eventType\":\""
         + EventType.CREATE_TABLE.toString()
-        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":\"{}\"}"));
+        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":{}}"));
   }
 
   @Test
@@ -233,7 +233,7 @@ public class ApiarySnsListenerTest {
         + PROTOCOL_VERSION
         + "\",\"eventType\":\""
         + EventType.CREATE_TABLE.toString()
-        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":\"{}\"}"));
+        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":{}}"));
   }
 
   @Test(expected = PatternSyntaxException.class)
@@ -292,7 +292,8 @@ public class ApiarySnsListenerTest {
         + PROTOCOL_VERSION
         + "\",\"eventType\":\""
         + EventType.ADD_PARTITION.toString()
-        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":\"{MY_VAR_TWO=5, MY_VAR_ONE=true}\",\"partitionKeys\":{\"column_1\":\"string\",\"column_2\":\"int\",\"column_3\":\"string\"},\"partitionValues\":[\"value_1\",\"1000\",\"value_2\"],\"partitionLocation\":\"s3://table_location/partition_location=2\"}"));
+        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":{\"MY_VAR_TWO\":\"5\",\"MY_VAR_ONE\":\"true\"},"
+        + "\"partitionKeys\":{\"column_1\":\"string\",\"column_2\":\"int\",\"column_3\":\"string\"},\"partitionValues\":[\"value_1\",\"1000\",\"value_2\"],\"partitionLocation\":\"s3://table_location/partition_location=2\"}"));
 
     verifyMessageAttributes(publishRequest, EventType.ADD_PARTITION.toString() );
   }
@@ -318,7 +319,7 @@ public class ApiarySnsListenerTest {
         + PROTOCOL_VERSION
         + "\",\"eventType\":\""
         + EventType.DROP_PARTITION.toString()
-        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":\"{MY_VAR_TWO=5, MY_VAR_ONE=true}\",\"partitionKeys\":{\"column_1\":\"string\",\"column_2\":\"int\",\"column_3\":\"string\"},\"partitionValues\":[\"value_1\",\"1000\",\"value_2\"],\"partitionLocation\":\"s3://table_location/partition_location=2\"}"));
+        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":{\"MY_VAR_TWO\":\"5\",\"MY_VAR_ONE\":\"true\"},\"partitionKeys\":{\"column_1\":\"string\",\"column_2\":\"int\",\"column_3\":\"string\"},\"partitionValues\":[\"value_1\",\"1000\",\"value_2\"],\"partitionLocation\":\"s3://table_location/partition_location=2\"}"));
 
     verifyMessageAttributes(publishRequest,  EventType.DROP_PARTITION.toString());
   }
@@ -337,7 +338,7 @@ public class ApiarySnsListenerTest {
         + PROTOCOL_VERSION
         + "\",\"eventType\":\""
         + EventType.DROP_TABLE.toString()
-        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":\"{MY_VAR_TWO=5, MY_VAR_ONE=true}\"}"));
+        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":{\"MY_VAR_TWO\":\"5\",\"MY_VAR_ONE\":\"true\"}}"));
 
     verifyMessageAttributes(publishRequest,  EventType.DROP_TABLE.toString());
   }
@@ -364,7 +365,7 @@ public class ApiarySnsListenerTest {
         + PROTOCOL_VERSION
         + "\",\"eventType\":\""
         + EventType.ALTER_PARTITION.toString()
-        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":\"{MY_VAR_TWO=5, MY_VAR_ONE=true}\",\"partitionKeys\":{\"column_1\":\"string\",\"column_2\":\"int\",\"column_3\":\"string\"},\"partitionValues\":[\"value_1\",\"1000\",\"value_2\"],\"partitionLocation\":\"s3://table_location/partition_location=2\",\"oldPartitionValues\":[\"value_1\",\"1000\",\"value_2\"],\"oldPartitionLocation\":\"s3://table_location/partition_location=1\"}"));
+        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":{\"MY_VAR_TWO\":\"5\",\"MY_VAR_ONE\":\"true\"},\"partitionKeys\":{\"column_1\":\"string\",\"column_2\":\"int\",\"column_3\":\"string\"},\"partitionValues\":[\"value_1\",\"1000\",\"value_2\"],\"partitionLocation\":\"s3://table_location/partition_location=2\",\"oldPartitionValues\":[\"value_1\",\"1000\",\"value_2\"],\"oldPartitionLocation\":\"s3://table_location/partition_location=1\"}"));
   }
 
   @Test
@@ -389,7 +390,7 @@ public class ApiarySnsListenerTest {
         + PROTOCOL_VERSION
         + "\",\"eventType\":\""
         + EventType.ALTER_PARTITION.toString()
-        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":\"{MY_VAR_TWO=5, MY_VAR_ONE=true}\",\"partitionKeys\":{\"column_1\":\"string\",\"column_2\":\"int\",\"column_3\":\"string\"},\"partitionValues\":[\"value_3\",\"2000\",\"value_4\"],\"partitionLocation\":\"s3://table_location/partition_location=2\",\"oldPartitionValues\":[\"value_1\",\"1000\",\"value_2\"],\"oldPartitionLocation\":\"s3://table_location/partition_location=2\"}"));
+        + "\",\"dbName\":\"some_db\",\"tableName\":\"some_table\",\"tableLocation\":\"s3://table_location\",\"tableParameters\":{\"MY_VAR_TWO\":\"5\",\"MY_VAR_ONE\":\"true\"},\"partitionKeys\":{\"column_1\":\"string\",\"column_2\":\"int\",\"column_3\":\"string\"},\"partitionValues\":[\"value_3\",\"2000\",\"value_4\"],\"partitionLocation\":\"s3://table_location/partition_location=2\",\"oldPartitionValues\":[\"value_1\",\"1000\",\"value_2\"],\"oldPartitionLocation\":\"s3://table_location/partition_location=2\"}"));
   }
 
   @Test
@@ -413,7 +414,7 @@ public class ApiarySnsListenerTest {
         + PROTOCOL_VERSION
         + "\",\"eventType\":\""
         + EventType.ALTER_TABLE.toString()
-        + "\",\"dbName\":\"some_db\",\"tableName\":\"new_some_table\",\"tableLocation\":\"s3://table_location_1\",\"tableParameters\":\"{MY_VAR_TWO=5, MY_VAR_ONE=true}\",\"oldTableName\":\"some_table\",\"oldTableLocation\":\"s3://table_location\"}"));
+        + "\",\"dbName\":\"some_db\",\"tableName\":\"new_some_table\",\"tableLocation\":\"s3://table_location_1\",\"tableParameters\":{\"MY_VAR_TWO\":\"5\",\"MY_VAR_ONE\":\"true\"},\"oldTableName\":\"some_table\",\"oldTableLocation\":\"s3://table_location\"}"));
     verifyMessageAttributes(publishRequest,  EventType.ALTER_TABLE.toString());
   }
 


### PR DESCRIPTION
The table parameters on a Hive Metastore event should be serialised as a Map, but are currently serialised as a String.

Current:
```
... ,\"tableParameters\":\"{MY_VAR_TWO=5, MY_VAR_ONE=true}\", ...
```


Fix:
```
... ,\"tableParameters\":{\"MY_VAR_TWO\":\"5\",\"MY_VAR_ONE\":\"true\"}, ...
```
