### PR TITLE
Add support for Ranger audit-only mode on readonly HMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 4.2.0 - TBD
+### Added
+- `apiary-ranger-metastore-plugin` module has an `ApiaryRangerAuthAllAccessPolicyProvider` class that can be configured in ranger-hive-security.xml to allow for an audit-only Ranger pre-event listener. Intent is to configure it on the Apiary read-only HMS instances.
+
+
 ## 4.1.0 - 2019-06-27
 ### Added
 - `privileges-grantor-lambda` supports granting access to tables that were renamed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 4.2.0 - TBD
+## 4.2.0 - 2019-08-02
 ### Added
 - `apiary-ranger-metastore-plugin` module has an `ApiaryRangerAuthAllAccessPolicyProvider` class that can be configured in ranger-hive-security.xml to allow for an audit-only Ranger pre-event listener. Intent is to configure it on the Apiary read-only HMS instances.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 4.1.0 - TBD
+## 4.1.0 - 2019-06-27
 ### Added
 - `privileges-grantor-lambda` supports granting access to tables that were renamed.
 - `apiary-metastore-consumers` sub-module of `apiary-metastore-events`.

--- a/apiary-gluesync-listener/pom.xml
+++ b/apiary-gluesync-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-gluesync-listener</artifactId>

--- a/apiary-metastore-auth/pom.xml
+++ b/apiary-metastore-auth/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-auth</artifactId>

--- a/apiary-metastore-events/apiary-metastore-consumers/metastore-consumer-common/pom.xml
+++ b/apiary-metastore-events/apiary-metastore-consumers/metastore-consumer-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.expediagroup.apiary</groupId>
         <artifactId>apiary-metastore-consumers-parent</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metastore-consumer-common</artifactId>

--- a/apiary-metastore-events/apiary-metastore-consumers/pom.xml
+++ b/apiary-metastore-events/apiary-metastore-consumers/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.expediagroup.apiary</groupId>
         <artifactId>apiary-metastore-events-parent</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apiary-metastore-consumers-parent</artifactId>

--- a/apiary-metastore-events/apiary-metastore-consumers/privileges-grantor/pom.xml
+++ b/apiary-metastore-events/apiary-metastore-consumers/privileges-grantor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.expediagroup.apiary</groupId>
         <artifactId>apiary-metastore-consumers-parent</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apiary-privileges-grantor-parent</artifactId>

--- a/apiary-metastore-events/apiary-metastore-consumers/privileges-grantor/privileges-grantor-core/pom.xml
+++ b/apiary-metastore-events/apiary-metastore-consumers/privileges-grantor/privileges-grantor-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.expediagroup.apiary</groupId>
         <artifactId>apiary-privileges-grantor-parent</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apiary-privileges-grantor-core</artifactId>

--- a/apiary-metastore-events/apiary-metastore-consumers/privileges-grantor/privileges-grantor-lambda/pom.xml
+++ b/apiary-metastore-events/apiary-metastore-consumers/privileges-grantor/privileges-grantor-lambda/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.expediagroup.apiary</groupId>
         <artifactId>apiary-privileges-grantor-parent</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apiary-privileges-grantor-lambda</artifactId>

--- a/apiary-metastore-events/apiary-metastore-listener/pom.xml
+++ b/apiary-metastore-events/apiary-metastore-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-metastore-events-parent</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-listener</artifactId>

--- a/apiary-metastore-events/apiary-receivers/apiary-receiver-common/pom.xml
+++ b/apiary-metastore-events/apiary-receivers/apiary-receiver-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-receivers-parent</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-receiver-common</artifactId>

--- a/apiary-metastore-events/apiary-receivers/apiary-receiver-sqs/pom.xml
+++ b/apiary-metastore-events/apiary-receivers/apiary-receiver-sqs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-receivers-parent</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-receiver-sqs</artifactId>

--- a/apiary-metastore-events/apiary-receivers/pom.xml
+++ b/apiary-metastore-events/apiary-receivers/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-metastore-events-parent</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-receivers-parent</artifactId>

--- a/apiary-metastore-events/pom.xml
+++ b/apiary-metastore-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-events-parent</artifactId>

--- a/apiary-metastore-metrics/pom.xml
+++ b/apiary-metastore-metrics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-metrics</artifactId>

--- a/apiary-ranger-metastore-plugin/pom.xml
+++ b/apiary-ranger-metastore-plugin/pom.xml
@@ -96,6 +96,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/apiary-ranger-metastore-plugin/pom.xml
+++ b/apiary-ranger-metastore-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-ranger-metastore-plugin</artifactId>
@@ -98,7 +98,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
+      <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/apiary-ranger-metastore-plugin/src/main/java/com/expediagroup/apiary/extensions/rangerauth/listener/ApiaryRangerAuthPreEventListener.java
+++ b/apiary-ranger-metastore-plugin/src/main/java/com/expediagroup/apiary/extensions/rangerauth/listener/ApiaryRangerAuthPreEventListener.java
@@ -83,13 +83,13 @@ public class ApiaryRangerAuthPreEventListener extends MetaStorePreEventListener 
     plugin = new RangerBasePlugin("hive", "metastore");
     plugin.init();
     plugin.setResultProcessor(new RangerDefaultAuditHandler());
-    log.debug("ApiaryRangerAuthPreEventListener created");
+    log.info("ApiaryRangerAuthPreEventListener created");
   }
 
   public ApiaryRangerAuthPreEventListener(Configuration config, RangerBasePlugin plugin) throws HiveException {
     super(config);
     this.plugin = plugin;
-    log.debug("ApiaryRangerAuthPreEventListener created");
+    log.info("ApiaryRangerAuthPreEventListener created");
   }
 
   @Override
@@ -229,5 +229,4 @@ public class ApiaryRangerAuthPreEventListener extends MetaStorePreEventListener 
     }
 
   }
-
 }

--- a/apiary-ranger-metastore-plugin/src/main/java/com/expediagroup/apiary/extensions/rangerauth/listener/ApiaryRangerAuthPreEventListener.java
+++ b/apiary-ranger-metastore-plugin/src/main/java/com/expediagroup/apiary/extensions/rangerauth/listener/ApiaryRangerAuthPreEventListener.java
@@ -15,9 +15,7 @@
  */
 package com.expediagroup.apiary.extensions.rangerauth.listener;
 
-import java.util.Date;
-import java.util.Set;
-
+import com.google.common.collect.Sets;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.MetaStorePreEventListener;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -50,8 +48,8 @@ import org.apache.ranger.plugin.policyengine.RangerAccessResult;
 import org.apache.ranger.plugin.service.RangerBasePlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Sets;
+import java.util.Date;
+import java.util.Set;
 
 enum HiveAccessType {
   NONE,
@@ -83,13 +81,13 @@ public class ApiaryRangerAuthPreEventListener extends MetaStorePreEventListener 
     plugin = new RangerBasePlugin("hive", "metastore");
     plugin.init();
     plugin.setResultProcessor(new RangerDefaultAuditHandler());
-    log.info("ApiaryRangerAuthPreEventListener created");
+    log.debug("ApiaryRangerAuthPreEventListener created");
   }
 
   public ApiaryRangerAuthPreEventListener(Configuration config, RangerBasePlugin plugin) throws HiveException {
     super(config);
     this.plugin = plugin;
-    log.info("ApiaryRangerAuthPreEventListener created");
+    log.debug("ApiaryRangerAuthPreEventListener created");
   }
 
   @Override

--- a/apiary-ranger-metastore-plugin/src/main/java/com/expediagroup/apiary/extensions/rangerauth/listener/ApiaryRangerAuthPreEventListener.java
+++ b/apiary-ranger-metastore-plugin/src/main/java/com/expediagroup/apiary/extensions/rangerauth/listener/ApiaryRangerAuthPreEventListener.java
@@ -15,7 +15,9 @@
  */
 package com.expediagroup.apiary.extensions.rangerauth.listener;
 
-import com.google.common.collect.Sets;
+import java.util.Date;
+import java.util.Set;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.MetaStorePreEventListener;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -48,8 +50,8 @@ import org.apache.ranger.plugin.policyengine.RangerAccessResult;
 import org.apache.ranger.plugin.service.RangerBasePlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.util.Date;
-import java.util.Set;
+
+import com.google.common.collect.Sets;
 
 enum HiveAccessType {
   NONE,
@@ -227,4 +229,5 @@ public class ApiaryRangerAuthPreEventListener extends MetaStorePreEventListener 
     }
 
   }
+
 }

--- a/apiary-ranger-metastore-plugin/src/main/java/com/expediagroup/apiary/extensions/rangerauth/policyproviders/ApiaryRangerAuthAllAccessPolicyProvider.java
+++ b/apiary-ranger-metastore-plugin/src/main/java/com/expediagroup/apiary/extensions/rangerauth/policyproviders/ApiaryRangerAuthAllAccessPolicyProvider.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (C) 2018-2019 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.apiary.extensions.rangerauth.policyproviders;
+
+import com.expediagroup.apiary.extensions.rangerauth.listener.ApiaryRangerAuthPreEventListener;
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.ranger.admin.client.RangerAdminClient;
+import org.apache.ranger.admin.client.RangerAdminRESTClient;
+import org.apache.ranger.plugin.model.RangerPolicy;
+import org.apache.ranger.plugin.util.GrantRevokeRequest;
+import org.apache.ranger.plugin.util.ServicePolicies;
+import org.apache.ranger.plugin.util.ServiceTags;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class to return a list of Ranger authorization policies that permits all access.  If this is configured in
+ * ranger-hive-security.xml in the "ranger.plugin.hive.policy.source.impl" property, Ranger will allow all actions.
+ * <p>
+ * The intent of this class is to only configure it on the Apiary read-only metastore so that Ranger auditing can still
+ * be used without Ranger authorization policies.  We have to do it this way, because Ranger auditing is down in the
+ * guts of the policy evaluation code, so there isn't a cleaner way to audit without policies that I can find.
+ */
+
+public class ApiaryRangerAuthAllAccessPolicyProvider implements RangerAdminClient {
+  @VisibleForTesting
+  static final List<String> ACCESS_NAMES =
+      Arrays.asList("select", "update", "create", "drop", "alter", "index", "lock", "all", "read", "write");
+
+  @VisibleForTesting
+  static final List<String> POLICY_RESOURCES = Arrays.asList("database", "column", "table");
+
+  @VisibleForTesting
+  static final String ALL_USERS_GROUP = "public";
+
+  private static final Logger log = LoggerFactory.getLogger(ApiaryRangerAuthPreEventListener.class);
+
+  private ServicePolicies servicePolicies;
+  private RangerAdminRESTClient rangerAdminRESTClient;
+
+
+  public ApiaryRangerAuthAllAccessPolicyProvider() {
+    log.info("Creating instance of ApiaryRangerAuthAllAccessPolicyProvider for Apiary read-only metastore");
+    this.rangerAdminRESTClient = new RangerAdminRESTClient();
+  }
+
+  public ApiaryRangerAuthAllAccessPolicyProvider(RangerAdminRESTClient rangerAdminRESTClient) {
+    log.info("Creating instance of ApiaryRangerAuthAllAccessPolicyProvider for Apiary read-only metastore");
+    this.rangerAdminRESTClient = rangerAdminRESTClient;
+  }
+
+  @Override
+  public void init(String serviceName, String appId, String configPropertyPrefix) {
+    servicePolicies = new ServicePolicies();
+    servicePolicies.setServiceName(serviceName);
+    servicePolicies.setServiceId(1L);
+    servicePolicies.setPolicyVersion(1L);
+    servicePolicies.setPolicyUpdateTime(new Date());
+
+    List<RangerPolicy> policies = new ArrayList<>();
+    policies.add(getPolicy(1L, serviceName, POLICY_RESOURCES));
+    servicePolicies.setPolicies(policies);
+
+    rangerAdminRESTClient.init(serviceName, appId, configPropertyPrefix);
+    log.info("Successfully initialized ApiaryRangerAuthAllAccessPolicyProvider");
+  }
+
+  @Override
+  public ServicePolicies getServicePoliciesIfUpdated(long lastKnownVersion, long lastActivationTimeInMillis) throws Exception {
+    ServicePolicies realServicePolicies = rangerAdminRESTClient.getServicePoliciesIfUpdated(lastKnownVersion, lastActivationTimeInMillis);
+
+    // Use the real Service Definition from Ranger Admin in our hardcoded policies so our policies match the real service def.
+    servicePolicies.setServiceDef(realServicePolicies.getServiceDef());
+    return servicePolicies;
+  }
+
+  @Override
+  public void grantAccess(GrantRevokeRequest request) throws Exception {
+  }
+
+  @Override
+  public void revokeAccess(GrantRevokeRequest request) throws Exception {
+  }
+
+  @Override
+  public ServiceTags getServiceTagsIfUpdated(long lastKnownVersion, long lastActivationTimeInMillis) throws Exception {
+    return null;
+  }
+
+  @Override
+  public List<String> getTagTypes(String tagTypePattern) throws Exception {
+    return null;
+  }
+
+  private RangerPolicy getPolicy(long policyId, String serviceName, List<String> resources) {
+    RangerPolicy policy = new RangerPolicy();
+    policy.setId(policyId);
+    policy.setService(serviceName);
+    policy.setPolicyType(RangerPolicy.POLICY_TYPE_ACCESS);
+    policy.setPolicyPriority(RangerPolicy.POLICY_PRIORITY_NORMAL);
+
+    Map<String, RangerPolicy.RangerPolicyResource> policyResources = new HashMap<>();
+    for (String resource : resources) {
+      policyResources.put(resource, new RangerPolicy.RangerPolicyResource("*", false, false));
+    }
+    policy.setResources(policyResources);
+    policy.setPolicyItems(getAllPolicyItems());
+    policy.setDenyPolicyItems(Collections.emptyList());
+    policy.setAllowExceptions(Collections.emptyList());
+    policy.setDenyExceptions(Collections.emptyList());
+    policy.setValiditySchedules(Collections.emptyList());
+    policy.setPolicyLabels(Collections.emptyList());
+    policy.setOptions(Collections.emptyMap());
+
+    return policy;
+  }
+
+  private List<RangerPolicy.RangerPolicyItem> getAllPolicyItems() {
+    RangerPolicy.RangerPolicyItem policyItem = new RangerPolicy.RangerPolicyItem();
+
+    List<RangerPolicy.RangerPolicyItemAccess> accesses = new ArrayList<>();
+
+    for (String accessName : ACCESS_NAMES) {
+      accesses.add(new RangerPolicy.RangerPolicyItemAccess(accessName, true));
+    }
+    policyItem.setAccesses(accesses);
+    policyItem.setGroups(Arrays.asList(ALL_USERS_GROUP));
+    policyItem.setUsers(Collections.emptyList());
+    policyItem.setConditions(Collections.emptyList());
+    policyItem.setDelegateAdmin(false);
+
+    return Arrays.asList(policyItem);
+  }
+
+  @VisibleForTesting
+  ServicePolicies getServicePolicies() {
+    return servicePolicies;
+  }
+}

--- a/apiary-ranger-metastore-plugin/src/test/java/com/expediagroup/apiary/extensions/rangerauth/policyproviders/ApiaryRangerAuthAllAccessPolicyProviderTest.java
+++ b/apiary-ranger-metastore-plugin/src/test/java/com/expediagroup/apiary/extensions/rangerauth/policyproviders/ApiaryRangerAuthAllAccessPolicyProviderTest.java
@@ -55,7 +55,7 @@ public class ApiaryRangerAuthAllAccessPolicyProviderTest {
   private String configPropertyPrefix = "prefix";
 
   @Test
-  public void test_init() {
+  public void init() {
     ApiaryRangerAuthAllAccessPolicyProvider apiaryRangerAuthAllAccessPolicyProvider =
         new ApiaryRangerAuthAllAccessPolicyProvider(rangerAdminRESTClient);
 
@@ -75,7 +75,7 @@ public class ApiaryRangerAuthAllAccessPolicyProviderTest {
   }
 
   @Test
-  public void test_getServicePoliciesIfUpdated() throws Exception {
+  public void getServicePoliciesIfUpdated() throws Exception {
 
     RangerAdminClientImpl testImpl = new RangerAdminClientImpl();
     testImpl.init(serviceName, appId, "ranger.plugin.hive");
@@ -99,7 +99,7 @@ public class ApiaryRangerAuthAllAccessPolicyProviderTest {
   }
 
   @Test
-  public void test_pluginAllowsAllAccess() throws Exception {
+  public void pluginAllowsAllAccess() throws Exception {
     RangerAdminClientImpl testImpl = new RangerAdminClientImpl();
     testImpl.init(serviceName, appId, "ranger.plugin.hive");
     ServicePolicies jsonPolicies = testImpl.getServicePoliciesIfUpdated(1L, 1L);

--- a/apiary-ranger-metastore-plugin/src/test/java/com/expediagroup/apiary/extensions/rangerauth/policyproviders/ApiaryRangerAuthAllAccessPolicyProviderTest.java
+++ b/apiary-ranger-metastore-plugin/src/test/java/com/expediagroup/apiary/extensions/rangerauth/policyproviders/ApiaryRangerAuthAllAccessPolicyProviderTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (C) 2018-2019 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.apiary.extensions.rangerauth.policyproviders;
+
+import com.expediagroup.apiary.extensions.rangerauth.listener.RangerAdminClientImpl;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.security.authorization.plugin.HiveOperationType;
+import org.apache.ranger.admin.client.RangerAdminRESTClient;
+import org.apache.ranger.plugin.model.RangerPolicy;
+import org.apache.ranger.plugin.model.RangerServiceDef;
+import org.apache.ranger.plugin.policyengine.RangerAccessRequest;
+import org.apache.ranger.plugin.policyengine.RangerAccessRequestImpl;
+import org.apache.ranger.plugin.policyengine.RangerAccessResourceImpl;
+import org.apache.ranger.plugin.policyengine.RangerAccessResult;
+import org.apache.ranger.plugin.policyengine.RangerPolicyEngineImpl;
+import org.apache.ranger.plugin.util.ServicePolicies;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.internal.util.collections.Sets;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Date;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApiaryRangerAuthAllAccessPolicyProviderTest {
+  @Mock
+  private RangerAdminRESTClient rangerAdminRESTClient;
+  @Mock
+  private Configuration configuration;
+
+  private static final String serviceName = "apiary";
+  private static final String appId = "appid";
+  private static final String configPropertyPrefix = "prefix";
+
+  @Before
+  public void setup() {
+    initMocks(this);
+  }
+
+  @Test
+  public void test_init() {
+    ApiaryRangerAuthAllAccessPolicyProvider apiaryRangerAuthAllAccessPolicyProvider =
+        new ApiaryRangerAuthAllAccessPolicyProvider(rangerAdminRESTClient);
+
+    apiaryRangerAuthAllAccessPolicyProvider.init(serviceName, appId, configPropertyPrefix);
+    verify(rangerAdminRESTClient, times(1)).init(anyString(), anyString(), anyString());
+
+    ServicePolicies servicePolicies = apiaryRangerAuthAllAccessPolicyProvider.getServicePolicies();
+    assertThat(servicePolicies.getPolicies(), hasSize(1));
+
+    assertThat(servicePolicies.getPolicies().get(0).getPolicyItems(), hasSize(1));
+
+    assertThat(servicePolicies.getPolicies().get(0).getPolicyItems().get(0).getGroups(),
+        hasItems(ApiaryRangerAuthAllAccessPolicyProvider.ALL_USERS_GROUP));
+
+    assertThat(servicePolicies.getPolicies().get(0).getPolicyItems().get(0).getAccesses(),
+        hasSize(ApiaryRangerAuthAllAccessPolicyProvider.ACCESS_NAMES.size()));
+  }
+
+  @Test
+  public void test_getServicePoliciesIfUpdated() throws Exception {
+
+    RangerAdminClientImpl testImpl = new RangerAdminClientImpl();
+    testImpl.init(serviceName, appId, "ranger.plugin.hive");
+    ServicePolicies jsonPolicies = testImpl.getServicePoliciesIfUpdated(1L, 1L);
+
+    doReturn(jsonPolicies).when(rangerAdminRESTClient).getServicePoliciesIfUpdated(anyLong(), anyLong());
+
+    ApiaryRangerAuthAllAccessPolicyProvider apiaryRangerAuthAllAccessPolicyProvider =
+        new ApiaryRangerAuthAllAccessPolicyProvider(rangerAdminRESTClient);
+
+    apiaryRangerAuthAllAccessPolicyProvider.init(serviceName, appId, configPropertyPrefix);
+
+    ServicePolicies servicePolicies = apiaryRangerAuthAllAccessPolicyProvider.
+        getServicePoliciesIfUpdated(1L, 1L);
+
+    // validate that we are *not* getting back the policies from the mocked JSON policy file, and that we *are*
+    // getting back the service definition from the mocked JSON policy file.
+
+    assertThat(jsonPolicies.getPolicies(), hasSize(10));
+    assertThat(servicePolicies.getPolicies(), hasSize(1));
+
+    assertThat(jsonPolicies.getServiceDef().getGuid(), equalTo(servicePolicies.getServiceDef().getGuid()));
+  }
+
+  @Test
+  public void test_pluginAllowsAllAccess() throws Exception {
+    RangerAdminClientImpl testImpl = new RangerAdminClientImpl();
+    testImpl.init(serviceName, appId, "ranger.plugin.hive");
+    ServicePolicies jsonPolicies = testImpl.getServicePoliciesIfUpdated(1L, 1L);
+
+    doReturn(jsonPolicies).when(rangerAdminRESTClient).getServicePoliciesIfUpdated(anyLong(), anyLong());
+
+    ApiaryRangerAuthAllAccessPolicyProvider apiaryRangerAuthAllAccessPolicyProvider =
+        new ApiaryRangerAuthAllAccessPolicyProvider(rangerAdminRESTClient);
+
+    apiaryRangerAuthAllAccessPolicyProvider.init(serviceName, appId, configPropertyPrefix);
+
+    ServicePolicies servicePolicies = apiaryRangerAuthAllAccessPolicyProvider.
+        getServicePoliciesIfUpdated(1L, 1L);
+
+    RangerPolicyEngineImpl rangerPolicyEngine = new RangerPolicyEngineImpl(appId, servicePolicies, null);
+
+    RangerAccessRequest request = getAccessRequest(servicePolicies.getServiceDef(), "testdb", "testtable", "testuser");
+    RangerAccessResult result = rangerPolicyEngine.evaluatePolicies(request, RangerPolicy.POLICY_TYPE_ACCESS, null);
+    assertThat(result.getIsAllowed(), equalTo(true));
+  }
+
+  private RangerAccessRequest getAccessRequest(RangerServiceDef serviceDef, String databaseName, String tableName, String user) {
+    RangerAccessResourceImpl resource = new RangerAccessResourceImpl();
+    resource.setServiceDef(serviceDef);
+    resource.setValue("database", databaseName);
+    resource.setValue("table", tableName);
+
+    Set<String> groups = Sets.newSet(user + "_group1", user + "_group2");
+    RangerAccessRequestImpl request = new RangerAccessRequestImpl(resource, "create", user, groups);
+    request.setAccessTime(new Date());
+    request.setAction(HiveOperationType.CREATETABLE.name());
+
+    return request;
+  }
+}

--- a/apiary-ranger-metastore-plugin/src/test/java/com/expediagroup/apiary/extensions/rangerauth/policyproviders/ApiaryRangerAuthAllAccessPolicyProviderTest.java
+++ b/apiary-ranger-metastore-plugin/src/test/java/com/expediagroup/apiary/extensions/rangerauth/policyproviders/ApiaryRangerAuthAllAccessPolicyProviderTest.java
@@ -15,6 +15,13 @@
  */
 package com.expediagroup.apiary.extensions.rangerauth.policyproviders;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import com.expediagroup.apiary.extensions.rangerauth.listener.RangerAdminClientImpl;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.security.authorization.plugin.HiveOperationType;
@@ -27,7 +34,6 @@ import org.apache.ranger.plugin.policyengine.RangerAccessResourceImpl;
 import org.apache.ranger.plugin.policyengine.RangerAccessResult;
 import org.apache.ranger.plugin.policyengine.RangerPolicyEngineImpl;
 import org.apache.ranger.plugin.util.ServicePolicies;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -37,17 +43,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.Date;
 import java.util.Set;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
-
 @RunWith(MockitoJUnitRunner.class)
 public class ApiaryRangerAuthAllAccessPolicyProviderTest {
   @Mock
@@ -55,14 +50,9 @@ public class ApiaryRangerAuthAllAccessPolicyProviderTest {
   @Mock
   private Configuration configuration;
 
-  private static final String serviceName = "apiary";
-  private static final String appId = "appid";
-  private static final String configPropertyPrefix = "prefix";
-
-  @Before
-  public void setup() {
-    initMocks(this);
-  }
+  private String serviceName = "apiary";
+  private String appId = "appid";
+  private String configPropertyPrefix = "prefix";
 
   @Test
   public void test_init() {
@@ -70,7 +60,7 @@ public class ApiaryRangerAuthAllAccessPolicyProviderTest {
         new ApiaryRangerAuthAllAccessPolicyProvider(rangerAdminRESTClient);
 
     apiaryRangerAuthAllAccessPolicyProvider.init(serviceName, appId, configPropertyPrefix);
-    verify(rangerAdminRESTClient, times(1)).init(anyString(), anyString(), anyString());
+    verify(rangerAdminRESTClient, times(1)).init(serviceName, appId, configPropertyPrefix);
 
     ServicePolicies servicePolicies = apiaryRangerAuthAllAccessPolicyProvider.getServicePolicies();
     assertThat(servicePolicies.getPolicies(), hasSize(1));
@@ -91,18 +81,16 @@ public class ApiaryRangerAuthAllAccessPolicyProviderTest {
     testImpl.init(serviceName, appId, "ranger.plugin.hive");
     ServicePolicies jsonPolicies = testImpl.getServicePoliciesIfUpdated(1L, 1L);
 
-    doReturn(jsonPolicies).when(rangerAdminRESTClient).getServicePoliciesIfUpdated(anyLong(), anyLong());
-
     ApiaryRangerAuthAllAccessPolicyProvider apiaryRangerAuthAllAccessPolicyProvider =
-        new ApiaryRangerAuthAllAccessPolicyProvider(rangerAdminRESTClient);
+        new ApiaryRangerAuthAllAccessPolicyProvider(testImpl);
 
     apiaryRangerAuthAllAccessPolicyProvider.init(serviceName, appId, configPropertyPrefix);
 
     ServicePolicies servicePolicies = apiaryRangerAuthAllAccessPolicyProvider.
         getServicePoliciesIfUpdated(1L, 1L);
 
-    // validate that we are *not* getting back the policies from the mocked JSON policy file, and that we *are*
-    // getting back the service definition from the mocked JSON policy file.
+    // validate that we are *not* getting back the policies from the test JSON policy file, and that we *are*
+    // getting back the service definition from the test JSON policy file.
 
     assertThat(jsonPolicies.getPolicies(), hasSize(10));
     assertThat(servicePolicies.getPolicies(), hasSize(1));
@@ -116,10 +104,8 @@ public class ApiaryRangerAuthAllAccessPolicyProviderTest {
     testImpl.init(serviceName, appId, "ranger.plugin.hive");
     ServicePolicies jsonPolicies = testImpl.getServicePoliciesIfUpdated(1L, 1L);
 
-    doReturn(jsonPolicies).when(rangerAdminRESTClient).getServicePoliciesIfUpdated(anyLong(), anyLong());
-
     ApiaryRangerAuthAllAccessPolicyProvider apiaryRangerAuthAllAccessPolicyProvider =
-        new ApiaryRangerAuthAllAccessPolicyProvider(rangerAdminRESTClient);
+        new ApiaryRangerAuthAllAccessPolicyProvider(testImpl);
 
     apiaryRangerAuthAllAccessPolicyProvider.init(serviceName, appId, configPropertyPrefix);
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>com.expediagroup.apiary</groupId>
   <artifactId>apiary-extensions-parent</artifactId>
   <description>Various extensions to Apiary that provide additional, optional functionality</description>
-  <version>4.1.1-SNAPSHOT</version>
+  <version>4.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apiary Extensions Parent</name>
   <inceptionYear>2018</inceptionYear>
@@ -70,7 +70,7 @@
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-all</artifactId>
+        <artifactId>hamcrest-library</artifactId>
         <version>${hamcrest.version}</version>
         <scope>test</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <ranger.version>1.1.0</ranger.version>
     <junit.version>4.12</junit.version>
     <mockito.version>2.21.0</mockito.version>
+    <hamcrest.version>1.3</hamcrest.version>
     <shade.prefix>${project.groupId}.shaded</shade.prefix>
     <slf4j.version>1.7.25</slf4j.version>
     <beeju.version>1.3.0</beeju.version>
@@ -65,6 +66,12 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-all</artifactId>
+        <version>${hamcrest.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
This PR creates a new class `ApiaryRangerAuthAllAccessPolicyProvider` that implements the interface that Ranger HMS plugin uses to load authorization policies.  This class returns a single policy that allows all access, since we are relying on other features of the HMS RO endpoint to filter out certain schemas, and to enforce read-only access.

This class will be set in the `ranger.plugin.hive.policy.source.impl` property of the `/etc/hive/conf/ranger-hive-security.xml` file by the `apiary-metastore-docker` project for the RO HMS instance.