### PR TITLE
Upgrade ranger plugin to 2.0.0

### DIFF
--- a/hive-metastore-events/apiary-ranger-metastore-plugin/src/main/java/com/expediagroup/apiary/extensions/rangerauth/policyproviders/ApiaryRangerAuthAllAccessPolicyProvider.java
+++ b/hive-metastore-events/apiary-ranger-metastore-plugin/src/main/java/com/expediagroup/apiary/extensions/rangerauth/policyproviders/ApiaryRangerAuthAllAccessPolicyProvider.java
@@ -21,7 +21,9 @@ import com.google.common.collect.ImmutableList;
 import org.apache.ranger.admin.client.RangerAdminClient;
 import org.apache.ranger.admin.client.RangerAdminRESTClient;
 import org.apache.ranger.plugin.model.RangerPolicy;
+import org.apache.ranger.plugin.model.RangerRole;
 import org.apache.ranger.plugin.util.GrantRevokeRequest;
+import org.apache.ranger.plugin.util.GrantRevokeRoleRequest;
 import org.apache.ranger.plugin.util.ServicePolicies;
 import org.apache.ranger.plugin.util.ServiceTags;
 import org.slf4j.Logger;
@@ -86,6 +88,30 @@ public class ApiaryRangerAuthAllAccessPolicyProvider implements RangerAdminClien
   }
 
   @Override
+  public RangerRole createRole(RangerRole request) throws Exception {
+    return request;
+  }
+
+  @Override
+  public void dropRole(String execUser, String roleName) throws Exception {
+  }
+
+  @Override
+  public List<String> getAllRoles(String execUser) throws Exception {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public List<String> getUserRoles(String execUser) throws Exception {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public RangerRole getRole(String execUser, String roleName) throws Exception {
+    return null;
+  }
+
+  @Override
   public ServicePolicies getServicePoliciesIfUpdated(long lastKnownVersion, long lastActivationTimeInMillis) throws Exception {
     ServicePolicies realServicePolicies = rangerAdminClient.getServicePoliciesIfUpdated(lastKnownVersion, lastActivationTimeInMillis);
 
@@ -100,6 +126,14 @@ public class ApiaryRangerAuthAllAccessPolicyProvider implements RangerAdminClien
 
   @Override
   public void revokeAccess(GrantRevokeRequest request) throws Exception {
+  }
+
+  @Override
+  public void grantRole(GrantRevokeRoleRequest request) throws Exception {
+  }
+
+  @Override
+  public void revokeRole(GrantRevokeRoleRequest request) throws Exception {
   }
 
   @Override

--- a/hive-metastore-events/apiary-ranger-metastore-plugin/src/test/java/com/expediagroup/apiary/extensions/rangerauth/listener/RangerAdminClientImpl.java
+++ b/hive-metastore-events/apiary-ranger-metastore-plugin/src/test/java/com/expediagroup/apiary/extensions/rangerauth/listener/RangerAdminClientImpl.java
@@ -31,10 +31,13 @@ package com.expediagroup.apiary.extensions.rangerauth.listener;
 import java.io.File;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.ranger.admin.client.RangerAdminClient;
+import org.apache.ranger.plugin.model.RangerRole;
 import org.apache.ranger.plugin.util.GrantRevokeRequest;
+import org.apache.ranger.plugin.util.GrantRevokeRoleRequest;
 import org.apache.ranger.plugin.util.ServicePolicies;
 import org.apache.ranger.plugin.util.ServiceTags;
 import org.slf4j.Logger;
@@ -105,5 +108,35 @@ public class RangerAdminClientImpl implements RangerAdminClient {
         return null;
     }
 
+    @Override
+    public RangerRole createRole(RangerRole request) throws Exception {
+        return request;
+    }
 
+    @Override
+    public void dropRole(String execUser, String roleName) throws Exception {
+    }
+
+    @Override
+    public List<String> getAllRoles(String execUser) throws Exception {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<String> getUserRoles(String execUser) throws Exception {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public RangerRole getRole(String execUser, String roleName) throws Exception {
+        return null;
+    }
+
+    @Override
+    public void grantRole(GrantRevokeRoleRequest request) throws Exception {
+    }
+
+    @Override
+    public void revokeRole(GrantRevokeRoleRequest request) throws Exception {
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <aws-java-sdk.version>1.11.333</aws-java-sdk.version>
     <hadoop.version>2.7.1</hadoop.version>
     <hive.version>2.3.3</hive.version>
-    <ranger.version>1.1.0</ranger.version>
+    <ranger.version>2.0.0</ranger.version>
     <junit.version>4.12</junit.version>
     <mockito.version>2.21.0</mockito.version>
     <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
### :pencil: Upgrade version of Ranger plugin to 2.0.0.  

Update stub implementations of interface to have new methods that do nothing/return nothing, since they are only used in tests.
