### PR TITLE
Update parent and scm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 - Moved `apiary-gluesync-listener`, `apiary-metastore-auth` and `apiary-ranger-metastore-plugin` (all previously top-level modules) to be submodules under a new top-level module named `hive-metastore-events`.
 - Grouped `apiary-metastore-consumers`, `apiary-metastore-listener` and `apiary-receivers` (all previously submodules in `apiary-metastore-events`) in a new module named `sns-metastore-events`, itself a submodule of `apiary-metastore-events`.
+- Changed parent to `com.expediagroup:eg-oss-parent:1.1.0` (was `com.hotels:hotels-oss-parent:4.0.1`).
 
 ## 4.2.0 - 2019-08-02
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.hotels</groupId>
-    <artifactId>hotels-oss-parent</artifactId>
-    <version>4.0.1</version>
+    <groupId>com.expediagroup</groupId>
+    <artifactId>eg-oss-parent</artifactId>
+    <version>1.1.0</version>
   </parent>
 
   <groupId>com.expediagroup.apiary</groupId>
@@ -17,8 +17,8 @@
   <inceptionYear>2018</inceptionYear>
 
   <scm>
-    <connection>scm:git:git@github.com:ExpediaGroup/apiary-extensions.git</connection>
-    <developerConnection>scm:git:git@github.com:ExpediaGroup/apiary-extensions.git</developerConnection>
+    <connection>scm:git:https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/ExpediaGroup/apiary-extensions.git</connection>
+    <developerConnection>scm:git:https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/ExpediaGroup/apiary-extensions.git</developerConnection>
     <url>https://github.com/ExpediaGroup/apiary-extensions</url>
     <tag>HEAD</tag>
   </scm>


### PR DESCRIPTION
- Changed parent to `com.expediagroup:eg-oss-parent:1.1.0` (was`com.hotels:hotels-oss-parent:4.0.1`).
- changed scm section to be https instead of ssh
