### PR TITLE
`eg-oss-parent` version updated to 1.2.0 (was 1.1.0).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.0.1] - TBD
+### Changed
+- `eg-oss-parent` version updated to 1.2.0 (was 1.1.0).
+
 ## 5.0.0 - 2019-12-09
 ### Changed
 - Moved `apiary-gluesync-listener`, `apiary-metastore-auth` and `apiary-ranger-metastore-plugin` (all previously top-level modules) to be submodules under a new top-level module named `hive-metastore-events`.

--- a/apiary-metastore-events/apiary-hive-events/src/test/java/com/expediagroup/apiary/extensions/events/metastore/io/jackson/JacksonThriftSerializerTest.java
+++ b/apiary-metastore-events/apiary-hive-events/src/test/java/com/expediagroup/apiary/extensions/events/metastore/io/jackson/JacksonThriftSerializerTest.java
@@ -32,8 +32,8 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
-import com.expediagroup.apiary.extensions.events.metastore.io.SerDeTestUtils;
 import com.expediagroup.apiary.extensions.events.metastore.io.SerDeException;
+import com.expediagroup.apiary.extensions.events.metastore.io.SerDeTestUtils;
 
 public class JacksonThriftSerializerTest {
 

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/test/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaMessageSenderTest.java
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/test/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaMessageSenderTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaMessageSender.kafkaProperties;
+import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaMessageSender.topic;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.ACKS;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.BATCH_SIZE;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.BOOTSTRAP_SERVERS;
@@ -27,8 +29,6 @@ import static com.expediagroup.apiary.extensions.events.metastore.kafka.messagin
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.RETRIES;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.TOPIC;
-import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaMessageSender.kafkaProperties;
-import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaMessageSender.topic;
 
 import java.util.Properties;
 
@@ -46,8 +46,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaMessage;
-import com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaMessageSender;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KafkaMessageSenderTest {

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/test/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaMessageTest.java
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/test/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaMessageTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
-import com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaMessage;
 
 public class KafkaMessageTest {
 

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/metastore-consumer-common/src/main/java/com/expediagroup/apiary/extensions/events/metastore/consumer/common/thrift/ThriftHiveClient.java
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/metastore-consumer-common/src/main/java/com/expediagroup/apiary/extensions/events/metastore/consumer/common/thrift/ThriftHiveClient.java
@@ -15,10 +15,11 @@
  */
 package com.expediagroup.apiary.extensions.events.metastore.consumer.common.thrift;
 
-import com.expediagroup.apiary.extensions.events.metastore.consumer.common.exception.HiveClientException;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+
+import com.expediagroup.apiary.extensions.events.metastore.consumer.common.exception.HiveClientException;
 
 /**
  * Exposes an instance of the Hive Metastore Thrift Api Client.

--- a/hive-metastore-events/apiary-ranger-metastore-plugin/src/main/java/com/expediagroup/apiary/extensions/rangerauth/policyproviders/ApiaryRangerAuthAllAccessPolicyProvider.java
+++ b/hive-metastore-events/apiary-ranger-metastore-plugin/src/main/java/com/expediagroup/apiary/extensions/rangerauth/policyproviders/ApiaryRangerAuthAllAccessPolicyProvider.java
@@ -15,9 +15,14 @@
  */
 package com.expediagroup.apiary.extensions.rangerauth.policyproviders;
 
-import com.expediagroup.apiary.extensions.rangerauth.listener.ApiaryRangerAuthPreEventListener;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.ranger.admin.client.RangerAdminClient;
 import org.apache.ranger.admin.client.RangerAdminRESTClient;
 import org.apache.ranger.plugin.model.RangerPolicy;
@@ -29,13 +34,10 @@ import org.apache.ranger.plugin.util.ServiceTags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+
+import com.expediagroup.apiary.extensions.rangerauth.listener.ApiaryRangerAuthPreEventListener;
 
 /**
  * Class to return a list of Ranger authorization policies that permits all access.  If this is configured in

--- a/hive-metastore-events/apiary-ranger-metastore-plugin/src/test/java/com/expediagroup/apiary/extensions/rangerauth/policyproviders/ApiaryRangerAuthAllAccessPolicyProviderTest.java
+++ b/hive-metastore-events/apiary-ranger-metastore-plugin/src/test/java/com/expediagroup/apiary/extensions/rangerauth/policyproviders/ApiaryRangerAuthAllAccessPolicyProviderTest.java
@@ -22,7 +22,9 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.expediagroup.apiary.extensions.rangerauth.listener.RangerAdminClientImpl;
+import java.util.Date;
+import java.util.Set;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.security.authorization.plugin.HiveOperationType;
 import org.apache.ranger.admin.client.RangerAdminRESTClient;
@@ -40,8 +42,7 @@ import org.mockito.Mock;
 import org.mockito.internal.util.collections.Sets;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.Date;
-import java.util.Set;
+import com.expediagroup.apiary.extensions.rangerauth.listener.RangerAdminClientImpl;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ApiaryRangerAuthAllAccessPolicyProviderTest {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.expediagroup</groupId>
     <artifactId>eg-oss-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <groupId>com.expediagroup.apiary</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.expediagroup</groupId>
     <artifactId>eg-oss-parent</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.0</version>
   </parent>
 
   <groupId>com.expediagroup.apiary</groupId>


### PR DESCRIPTION
Ensures consistent import ordering via the Spotless plugin included in this proposed change to the parent pom - https://github.com/ExpediaGroup/eg-oss-parent/pull/8/files