### PR TITLE
Upgrade solr jar version to match what Ranger 2.0.0 plugin expects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.0.1 - 2020-01-10
+### Changed
+- Upgraded Solr version to `7.7.1` (was `5.5.4`) to fix issue where Ranger plugin jar (version `2.0.0`) could not instantiate Solr client correctly.
+
 ## 5.0.0 - 2019-12-09
 ### Changed
 - Moved `apiary-gluesync-listener`, `apiary-metastore-auth` and `apiary-ranger-metastore-plugin` (all previously top-level modules) to be submodules under a new top-level module named `hive-metastore-events`.

--- a/hive-metastore-events/apiary-ranger-metastore-plugin/pom.xml
+++ b/hive-metastore-events/apiary-ranger-metastore-plugin/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-solrj</artifactId>
-      <version>5.5.4</version>
+      <version>${solr.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <hadoop.version>2.7.1</hadoop.version>
     <hive.version>2.3.3</hive.version>
     <ranger.version>2.0.0</ranger.version>
+    <solr.version>7.7.1</solr.version>
     <junit.version>4.12</junit.version>
     <mockito.version>2.21.0</mockito.version>
     <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
 <!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/apiary-extensions/blob/master/CONTRIBUTING.md
-->

### :pencil: Description

When `apiary-ranger-metastore-plugin` was upgraded to use Ranger `2.0.0`, the underlying Ranger 2.0.0 jars were built with a newer version of Solr that changed the classes uses to create the client.  However, this project was shading in the old version of Solr, causing a `ClassNotFoundException` whenever auditing via Solr was initializing.

This PR changes the shaded Solr version to the same version used by Apache to build Ranger `2.0.0`.

### :link: Related Issues