### PR TITLE
adding qualified name as message attribute for filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 - `eg-oss-parent` version updated to 1.2.0 (was 1.1.0).
 ### Added
-- Added `sns-metastore-event` SNS message attribute: `qualifiedTableName`.
+- `sns-metastore-event` SNS message attribute: `qualifiedTableName`.
 
 ## 5.0.1 - 2020-01-10
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [TBD] - TBD
+## 5.0.2 - 2020-02-04
 ### Changed
 - `eg-oss-parent` version updated to 1.2.0 (was 1.1.0).
+### Added
+- Added `sns-metastore-event` SNS message attribute: `qualifiedTableName`.
 
 ## 5.0.1 - 2020-01-10
 ### Changed

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-listener/README.md
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-listener/README.md
@@ -162,6 +162,7 @@ The following messages attributes are supported:
 |`eventType`|String|One of: CREATE_TABLE, DROP_TABLE, ALTER_TABLE, ADD_PARTITION, DROP_PARTITION, ALTER_PARTITION
 |`dbName`|String|Database name of the Hive table from which the event is emitted.
 |`tableName`|String|Name of the Hive table from which the event is emitted.
+|`qualifiedTableName`|String|Combined version of dbName and tableName: `my_db.my_table`.
 
 # Legal
 This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/events/metastore/listener/ApiarySnsListener.java
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/events/metastore/listener/ApiarySnsListener.java
@@ -223,12 +223,17 @@ public class ApiarySnsListener extends MetaStoreEventListener {
     map
         .put(MessageAttributeKey.DB_NAME.toString(),
             new MessageAttributeValue()
-                .withStringValue(dbName.toString())
+                .withStringValue(dbName)
                 .withDataType(MessageAttributeDataType.STRING.toString()));
     map
         .put(MessageAttributeKey.TABLE_NAME.toString(),
             new MessageAttributeValue()
-                .withStringValue(tableName.toString())
+                .withStringValue(tableName)
+                .withDataType(MessageAttributeDataType.STRING.toString()));
+    map
+        .put(MessageAttributeKey.QUALIFIED_TABLE_NAME.toString(),
+            new MessageAttributeValue()
+                .withStringValue(dbName + "." + tableName)
                 .withDataType(MessageAttributeDataType.STRING.toString()));
 
     return map;

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/events/metastore/listener/MessageAttributeKey.java
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/events/metastore/listener/MessageAttributeKey.java
@@ -19,7 +19,8 @@ public enum MessageAttributeKey {
 
   EVENT_TYPE("eventType"),
   DB_NAME("dbName"),
-  TABLE_NAME("tableName");
+  TABLE_NAME("tableName"),
+  QUALIFIED_TABLE_NAME("qualifiedTableName");
 
   private final String attribute;
 

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-listener/src/test/java/com/expediagroup/apiary/extensions/events/metastore/listener/ApiarySnsListenerTest.java
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-listener/src/test/java/com/expediagroup/apiary/extensions/events/metastore/listener/ApiarySnsListenerTest.java
@@ -424,16 +424,20 @@ public class ApiarySnsListenerTest {
       String dbName,
       String tableName) {
     Map<String, MessageAttributeValue> messageAttributes = publishRequest.getMessageAttributes();
-    assertThat(messageAttributes.size(), is(3));
+    assertThat(messageAttributes.size(), is(4));
     assertThat(messageAttributes.get(MessageAttributeKey.EVENT_TYPE.toString()).getStringValue(), is(eventType));
     assertThat(messageAttributes.get(MessageAttributeKey.DB_NAME.toString()).getStringValue(), is(dbName));
     assertThat(messageAttributes.get(MessageAttributeKey.TABLE_NAME.toString()).getStringValue(), is(tableName));
+    assertThat(messageAttributes.get(MessageAttributeKey.QUALIFIED_TABLE_NAME.toString()).getStringValue(),
+        is(dbName + "." + tableName));
 
     assertThat(messageAttributes.get(MessageAttributeKey.EVENT_TYPE.toString()).getDataType(),
         is(MessageAttributeDataType.STRING.toString()));
     assertThat(messageAttributes.get(MessageAttributeKey.DB_NAME.toString()).getDataType(),
         is(MessageAttributeDataType.STRING.toString()));
     assertThat(messageAttributes.get(MessageAttributeKey.TABLE_NAME.toString()).getDataType(),
+        is(MessageAttributeDataType.STRING.toString()));
+    assertThat(messageAttributes.get(MessageAttributeKey.QUALIFIED_TABLE_NAME.toString()).getDataType(),
         is(MessageAttributeDataType.STRING.toString()));
 
   }


### PR DESCRIPTION
Combined the db and table message attributes.

Being separate had the issue that a table with the same name in multiple dbs couldn't not easily subscribed to. Using qualified names it is more accurate.