### PR TITLE
Upgrade Hive to 2.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 6.0.2 - TBD
+### Changed
+- Upgraded version of `hive.version` to `2.3.7` (was `2.3.3`). Allows apiary-extensions to be used on JDK>=9.
+
 ## 6.0.1 - 2020-04-02
 ### Fixed
 - Bug in `privileges-grantor-lambda` where Apiary Events were not being deserialized properly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 6.0.2 - TBD
+## 6.0.2 - 2020-04-24
 ### Changed
 - Upgraded version of `hive.version` to `2.3.7` (was `2.3.3`). Allows apiary-extensions to be used on JDK>=9.
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <aws-java-sdk.version>1.11.333</aws-java-sdk.version>
     <hadoop.version>2.7.1</hadoop.version>
-    <hive.version>2.3.3</hive.version>
+    <hive.version>2.3.7</hive.version>
     <ranger.version>2.0.0</ranger.version>
     <solr.version>7.7.1</solr.version>
     <junit.version>4.12</junit.version>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/apiary-extensions/blob/master/CONTRIBUTING.md
-->

### :pencil: Description
* Upgraded version of `hive.version` to `2.3.7` (was `2.3.3`). Allows apiary-extensions to be used on JDK>=9.

### :link: Related Issues