### PR TITLE
Parent update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ jobs:
   test:
     name: Package and run all tests
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        java-version: [ 8, 11 ]    
     steps:
     - uses: actions/checkout@v2
       with:
@@ -26,6 +29,6 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: ${{ matrix.java-version }}
     - name: Run Maven Targets
-      run: mvn package jacoco:report coveralls:report --batch-mode --show-version --activate-profiles coveralls -Dcoveralls.skip=$COVERALLS_SKIP -DrepoToken=${{ secrets.COVERALLS_REPO_TOKEN }}
+      run: mvn package jacoco:report coveralls:report --batch-mode --show-version --no-transfer-progress --activate-profiles coveralls -Dcoveralls.skip=$COVERALLS_SKIP -DrepoToken=${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 7.1.0 - TBD
+## 7.1.0 - 2021-02-18
 ### Changed
 - Relocated Kafka libraries in `kafka-metastore-listener` under `com.expediagroup.apiary.extensions.shaded.org.apache.kafka` to avoid clashes when moving other components to a newer version of Kafka.
 - `eg-oss-parent` version updated to 2.3.2 (was 1.2.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 7.0.1 - TBD
+## 7.1.0 - TBD
 ### Changed
 - Relocated Kafka libraries in `kafka-metastore-listener` under `com.expediagroup.apiary.extensions.shaded.org.apache.kafka` to avoid clashes when moving other components to a newer version of Kafka.
-- `eg-oss-parent` version updated to 2.2.0 (was 1.2.0).
+- `eg-oss-parent` version updated to 2.3.1 (was 1.2.0).
 - `jdk.tools` excluded as a transitive dependency everywhere to allow compilation on Java 11.
 - A few transitive dependencies made explicit to allow compilation on Java 11.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## 7.1.0 - TBD
 ### Changed
 - Relocated Kafka libraries in `kafka-metastore-listener` under `com.expediagroup.apiary.extensions.shaded.org.apache.kafka` to avoid clashes when moving other components to a newer version of Kafka.
-- `eg-oss-parent` version updated to 2.3.1 (was 1.2.0).
+- `eg-oss-parent` version updated to 2.3.2 (was 1.2.0).
 - `jdk.tools` excluded as a transitive dependency everywhere to allow compilation on Java 11.
 - A few transitive dependencies made explicit to allow compilation on Java 11.
 

--- a/apiary-metastore-events/apiary-hive-events/pom.xml
+++ b/apiary-metastore-events/apiary-hive-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-metastore-events-parent</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-hive-events</artifactId>

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-integration-tests/pom.xml
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kafka-metastore-events-parent</artifactId>
     <groupId>com.expediagroup.apiary</groupId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kafka-metastore-integration-tests</artifactId>

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/pom.xml
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>kafka-metastore-events-parent</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kafka-metastore-listener</artifactId>

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-receiver/pom.xml
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-receiver/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kafka-metastore-events-parent</artifactId>
     <groupId>com.expediagroup.apiary</groupId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kafka-metastore-receiver</artifactId>

--- a/apiary-metastore-events/kafka-metastore-events/pom.xml
+++ b/apiary-metastore-events/kafka-metastore-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-metastore-events-parent</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kafka-metastore-events-parent</artifactId>

--- a/apiary-metastore-events/pom.xml
+++ b/apiary-metastore-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-events-parent</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/metastore-consumer-common/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/metastore-consumer-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-metastore-consumers-parent</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>metastore-consumer-common</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.expediagroup.apiary</groupId>
         <artifactId>sns-metastore-events-parent</artifactId>
-        <version>7.0.1-SNAPSHOT</version>
+        <version>7.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apiary-metastore-consumers-parent</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/privileges-grantor/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/privileges-grantor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.expediagroup.apiary</groupId>
         <artifactId>apiary-metastore-consumers-parent</artifactId>
-        <version>7.0.1-SNAPSHOT</version>
+        <version>7.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apiary-privileges-grantor-parent</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/privileges-grantor/privileges-grantor-core/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/privileges-grantor/privileges-grantor-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.expediagroup.apiary</groupId>
         <artifactId>apiary-privileges-grantor-parent</artifactId>
-        <version>7.0.1-SNAPSHOT</version>
+        <version>7.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apiary-privileges-grantor-core</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/privileges-grantor/privileges-grantor-lambda/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/privileges-grantor/privileges-grantor-lambda/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.expediagroup.apiary</groupId>
         <artifactId>apiary-privileges-grantor-parent</artifactId>
-        <version>7.0.1-SNAPSHOT</version>
+        <version>7.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apiary-privileges-grantor-lambda</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-listener/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>sns-metastore-events-parent</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-listener</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-receivers/apiary-receiver-common/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-receivers/apiary-receiver-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-receivers-parent</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-receiver-common</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-receivers/apiary-receiver-sqs/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-receivers/apiary-receiver-sqs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-receivers-parent</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-receiver-sqs</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-receivers/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-receivers/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>sns-metastore-events-parent</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-receivers-parent</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-metastore-events-parent</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>sns-metastore-events-parent</artifactId>

--- a/apiary-metastore-metrics/pom.xml
+++ b/apiary-metastore-metrics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-metrics</artifactId>

--- a/hive-event-listeners/apiary-gluesync-listener/pom.xml
+++ b/hive-event-listeners/apiary-gluesync-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>hive-event-listeners-parent</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-gluesync-listener</artifactId>

--- a/hive-event-listeners/apiary-metastore-auth/pom.xml
+++ b/hive-event-listeners/apiary-metastore-auth/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>hive-event-listeners-parent</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-auth</artifactId>

--- a/hive-event-listeners/apiary-ranger-metastore-plugin/pom.xml
+++ b/hive-event-listeners/apiary-ranger-metastore-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>hive-event-listeners-parent</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-ranger-metastore-plugin</artifactId>

--- a/hive-event-listeners/pom.xml
+++ b/hive-event-listeners/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>apiary-extensions-parent</artifactId>
     <groupId>com.expediagroup.apiary</groupId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>7.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hive-event-listeners-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>com.expediagroup</groupId>
     <artifactId>eg-oss-parent</artifactId>
-    <version>2.2.0</version>
+    <version>2.3.1</version>
   </parent>
 
   <groupId>com.expediagroup.apiary</groupId>
   <artifactId>apiary-extensions-parent</artifactId>
   <description>Various extensions to Apiary that provide additional, optional functionality</description>
-  <version>7.0.1-SNAPSHOT</version>
+  <version>7.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apiary Extensions Parent</name>
   <inceptionYear>2018</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup</groupId>
     <artifactId>eg-oss-parent</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
   </parent>
 
   <groupId>com.expediagroup.apiary</groupId>


### PR DESCRIPTION
Update to `2.3.2` of `eg-oss-parent` to check that changes there for Javadoc issues with certain versions of Java don't affect a downstream build. Added a GH action build matrix of both Java 8 and 11 to demonstrate this.