### PR TITLE
Fix gluesync when getting null SortOrders in Hive & Iceberg tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 7.3.6 - 2022-11-11
+### Fixed
+- `apiary-gluesync-listener` when getting null `SortOrder` in Hive & Iceberg tables.
+
 ## 7.3.5 - 2022-11-11
 ### Fixed
 - `apiary-gluesync-listener` when getting last access time in Hive & Iceberg tables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 7.3.6 - 2022-11-11
+## 7.3.6 - 2022-11-14
 ### Fixed
 - `apiary-gluesync-listener` when getting null `SortOrder` in Hive & Iceberg tables.
 

--- a/hive-event-listeners/apiary-gluesync-listener/pom.xml
+++ b/hive-event-listeners/apiary-gluesync-listener/pom.xml
@@ -81,6 +81,13 @@
       <artifactId>log4j-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-hive-metastore</artifactId>
+      <version>1.0.0</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/ApiaryGlueSync.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/ApiaryGlueSync.java
@@ -348,6 +348,10 @@ public class ApiaryGlueSync extends MetaStoreEventListener {
 
   private List<Order> extractSortOrders(final List<org.apache.hadoop.hive.metastore.api.Order> hiveOrders) {
     final List<Order> sortOrders = new ArrayList<>();
+    if (hiveOrders == null) {
+      return sortOrders;
+    }
+
     for (final org.apache.hadoop.hive.metastore.api.Order hiveOrder : hiveOrders) {
       final Order order = new Order().withSortOrder(hiveOrder.getOrder()).withColumn(hiveOrder.getCol());
       sortOrders.add(order);

--- a/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/ApiaryGlueSyncTest.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/ApiaryGlueSyncTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 
 import static com.google.common.collect.Maps.newHashMap;
 
-import static com.expediagroup.apiary.extensions.gluesync.listener.IcebergTableOperations.simpleIcebergPartitioning;
+import static com.expediagroup.apiary.extensions.gluesync.listener.IcebergTableOperations.simpleIcebergPartitionSpec;
 import static com.expediagroup.apiary.extensions.gluesync.listener.IcebergTableOperations.simpleIcebergSchema;
 import static com.expediagroup.apiary.extensions.gluesync.listener.IcebergTableOperations.simpleIcebergTable;
 
@@ -215,7 +215,7 @@ public class ApiaryGlueSyncTest {
     CreateTableEvent event = mock(CreateTableEvent.class);
     when(event.getStatus()).thenReturn(true);
 
-    Table table = simpleIcebergTable(dbName, tableName, simpleIcebergSchema(), simpleIcebergPartitioning(), null);
+    Table table = simpleIcebergTable(dbName, tableName, simpleIcebergSchema(), simpleIcebergPartitionSpec(), null);
     when(event.getTable()).thenReturn(table);
 
     glueSync.onCreateTable(event);

--- a/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/ApiaryGlueSyncTest.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/ApiaryGlueSyncTest.java
@@ -27,6 +27,10 @@ import static org.mockito.Mockito.when;
 
 import static com.google.common.collect.Maps.newHashMap;
 
+import static com.expediagroup.apiary.extensions.gluesync.listener.IcebergTableOperations.simpleIcebergPartitioning;
+import static com.expediagroup.apiary.extensions.gluesync.listener.IcebergTableOperations.simpleIcebergSchema;
+import static com.expediagroup.apiary.extensions.gluesync.listener.IcebergTableOperations.simpleIcebergTable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -188,7 +192,7 @@ public class ApiaryGlueSyncTest {
   }
 
   @Test
-  public void onCreateTable() {
+  public void onCreateHiveTable() {
     CreateTableEvent event = mock(CreateTableEvent.class);
     when(event.getStatus()).thenReturn(true);
 
@@ -207,7 +211,28 @@ public class ApiaryGlueSyncTest {
   }
 
   @Test
-  public void onAlterTable() {
+  public void onCreateIcebergTable() {
+    CreateTableEvent event = mock(CreateTableEvent.class);
+    when(event.getStatus()).thenReturn(true);
+
+    Table table = simpleIcebergTable(dbName, tableName, simpleIcebergSchema(), simpleIcebergPartitioning(), null);
+    when(event.getTable()).thenReturn(table);
+
+    glueSync.onCreateTable(event);
+
+    verify(glueClient).createTable(createTableRequestCaptor.capture());
+    CreateTableRequest createTableRequest = createTableRequestCaptor.getValue();
+
+    assertThat(createTableRequest.getDatabaseName(), is(gluePrefix + dbName));
+    assertThat(createTableRequest.getTableInput().getName(), is(tableName));
+    assertThat(createTableRequest.getTableInput().getStorageDescriptor().getInputFormat(), is("org.apache.iceberg.mr.hive.HiveIcebergInputFormat"));
+    assertThat(createTableRequest.getTableInput().getStorageDescriptor().getSerdeInfo().getSerializationLibrary(),
+        is("org.apache.iceberg.mr.hive.HiveIcebergSerDe"));
+    assertThat(toList(createTableRequest.getTableInput().getStorageDescriptor().getColumns()), is(asList(colNames)));
+  }
+
+  @Test
+  public void onAlterHiveTable() {
     AlterTableEvent event = mock(AlterTableEvent.class);
     when(event.getStatus()).thenReturn(true);
 
@@ -230,7 +255,7 @@ public class ApiaryGlueSyncTest {
   }
 
   @Test
-  public void onCreateUnpartitionedTable() {
+  public void onCreateUnpartitionedHiveTable() {
     CreateTableEvent event = mock(CreateTableEvent.class);
     when(event.getStatus()).thenReturn(true);
 

--- a/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/IcebergTableOperations.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/IcebergTableOperations.java
@@ -59,7 +59,7 @@ public class IcebergTableOperations {
         required(2, "col2", Types.StringType.get()), required(3, "col3", Types.IntegerType.get()));
   }
 
-  protected static PartitionSpec simpleIcebergPartitioning() {
+  protected static PartitionSpec simpleIcebergPartitionSpec() {
     return builderFor(simpleIcebergSchema()).identity("col1").build();
   }
 

--- a/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/IcebergTableOperations.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/IcebergTableOperations.java
@@ -22,7 +22,6 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.SortOrderParser;
-import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.hive.HiveSchemaUtil;
 import org.apache.iceberg.types.Types;
@@ -112,8 +111,7 @@ public class IcebergTableOperations {
 
   private static void setSortOrder(SortOrder sortOrder, Map<String, String> parameters) {
     parameters.remove(TableProperties.DEFAULT_SORT_ORDER);
-    if (sortOrder != null
-        && sortOrder.isSorted()) {
+    if (sortOrder != null && sortOrder.isSorted()) {
       String sortOrderJSON = SortOrderParser.toJson(sortOrder);
       parameters.put(TableProperties.DEFAULT_SORT_ORDER, sortOrderJSON);
     }

--- a/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/IcebergTableOperations.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/IcebergTableOperations.java
@@ -1,0 +1,121 @@
+package com.expediagroup.apiary.extensions.gluesync.listener;
+
+import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
+import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
+import static org.apache.iceberg.PartitionSpec.builderFor;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.apache.hadoop.hive.metastore.TableType;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.SortOrderParser;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.hive.HiveSchemaUtil;
+import org.apache.iceberg.types.Types;
+
+import com.google.common.collect.Maps;
+
+public class IcebergTableOperations {
+  protected static Table simpleIcebergTable(String database, String tableName, Schema schema, PartitionSpec partitionSpec,
+      SortOrder sortOrder) {
+    final long currentTimeMillis = System.currentTimeMillis();
+
+    Table newTable =
+        new Table(
+            tableName,
+            database,
+            System.getProperty("user.name"),
+            (int) currentTimeMillis / 1000,
+            (int) currentTimeMillis / 1000,
+            Integer.MAX_VALUE,
+            null,
+            Collections.emptyList(),
+            Maps.newHashMap(),
+            null,
+            null,
+            TableType.EXTERNAL_TABLE.toString());
+
+    newTable.getParameters().put("EXTERNAL", "TRUE");
+    newTable.setSd(storageDescriptor(schema));
+    setHmsTableParameters(newTable, schema, partitionSpec, sortOrder);
+    return newTable;
+  }
+
+  protected static Schema simpleIcebergSchema() {
+    return new Schema(required(1, "col1", Types.StringType.get()),
+        required(2, "col2", Types.StringType.get()), required(3, "col3", Types.IntegerType.get()));
+  }
+
+  protected static PartitionSpec simpleIcebergPartitioning() {
+    return builderFor(simpleIcebergSchema()).identity("col1").build();
+  }
+
+  private static StorageDescriptor storageDescriptor(Schema schema) {
+    final StorageDescriptor storageDescriptor = new StorageDescriptor();
+    storageDescriptor.setCols(HiveSchemaUtil.convert(schema));
+    storageDescriptor.setLocation("location");
+    SerDeInfo serDeInfo = new SerDeInfo();
+    serDeInfo.setParameters(Maps.newHashMap());
+    storageDescriptor.setInputFormat("org.apache.iceberg.mr.hive.HiveIcebergInputFormat");
+    storageDescriptor.setOutputFormat("org.apache.iceberg.mr.hive.HiveIcebergOutputFormat");
+    serDeInfo.setSerializationLib("org.apache.iceberg.mr.hive.HiveIcebergSerDe");
+    storageDescriptor.setSerdeInfo(serDeInfo);
+    return storageDescriptor;
+  }
+
+  private static void setHmsTableParameters(Table tbl, Schema schema, PartitionSpec partitionSpec, SortOrder sortOrder) {
+    Map<String, String> parameters =
+        Optional.ofNullable(tbl.getParameters()).orElseGet(Maps::newHashMap);
+
+    parameters.put(TableProperties.UUID, UUID.randomUUID().toString());
+    parameters.put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH));
+    parameters.put(
+        hive_metastoreConstants.META_TABLE_STORAGE,
+        "org.apache.iceberg.mr.hive.HiveIcebergStorageHandler");
+
+    setSchema(schema, parameters);
+    setPartitionSpec(partitionSpec, parameters);
+    setSortOrder(sortOrder, parameters);
+
+    tbl.setParameters(parameters);
+  }
+
+  private static void setSchema(Schema schema, Map<String, String> parameters) {
+    parameters.remove(TableProperties.CURRENT_SCHEMA);
+    if (schema != null) {
+      String schemaJSON = SchemaParser.toJson(schema);
+      parameters.put(TableProperties.CURRENT_SCHEMA, schemaJSON);
+    }
+  }
+
+  private static void setPartitionSpec(PartitionSpec partitionSpec, Map<String, String> parameters) {
+    parameters.remove(TableProperties.DEFAULT_PARTITION_SPEC);
+    if (partitionSpec != null && partitionSpec.isPartitioned()) {
+      String spec = PartitionSpecParser.toJson(partitionSpec);
+      parameters.put(TableProperties.DEFAULT_PARTITION_SPEC, spec);
+    }
+  }
+
+  private static void setSortOrder(SortOrder sortOrder, Map<String, String> parameters) {
+    parameters.remove(TableProperties.DEFAULT_SORT_ORDER);
+    if (sortOrder != null
+        && sortOrder.isSorted()) {
+      String sortOrderJSON = SortOrderParser.toJson(sortOrder);
+      parameters.put(TableProperties.DEFAULT_SORT_ORDER, sortOrderJSON);
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/apiary-extensions/blob/main/CONTRIBUTING.md
-->

### :pencil: Description


### :link: Related Issues