### PR TITLE
Add Kafka compression type for Kafka Metastore Listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 7.3.7 - 2023-07-19
+### Added
+- `compression.type` [Kafka property](https://docs.confluent.io/platform/current/installation/configuration/broker-configs.html#compression-type) in `kafka-metastore-listener`.
+
 ## 7.3.6 - 2022-11-14
 ### Fixed
 - `apiary-gluesync-listener` when getting null `SortOrder` in Hive & Iceberg tables.

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaMessageSender.java
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaMessageSender.java
@@ -24,6 +24,7 @@ import static com.expediagroup.apiary.extensions.events.metastore.kafka.messagin
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.BOOTSTRAP_SERVERS;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.BUFFER_MEMORY;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.CLIENT_ID;
+import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.COMPRESSION_TYPE;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.LINGER_MS;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.RETRIES;
@@ -77,6 +78,7 @@ public class KafkaMessageSender {
     props.put(BATCH_SIZE.unprefixedKey(), intProperty(conf, BATCH_SIZE));
     props.put(LINGER_MS.unprefixedKey(), longProperty(conf, LINGER_MS));
     props.put(BUFFER_MEMORY.unprefixedKey(), longProperty(conf, BUFFER_MEMORY));
+    props.put(COMPRESSION_TYPE.unprefixedKey(), stringProperty(conf, COMPRESSION_TYPE));
     props.put("key.serializer", "org.apache.kafka.common.serialization.LongSerializer");
     props.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
     return props;

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaProducerProperty.java
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaProducerProperty.java
@@ -28,7 +28,8 @@ public enum KafkaProducerProperty implements Property {
   BATCH_SIZE("batch.size", 16384),
   LINGER_MS("linger.ms", 1L),
   BUFFER_MEMORY("buffer.memory", 33554432L),
-  SERDE_CLASS("serde.class", JsonMetaStoreEventSerDe.class.getName());
+  SERDE_CLASS("serde.class", JsonMetaStoreEventSerDe.class.getName()),
+  COMPRESSION_TYPE("compression.type", "producer");
 
   private static final String HADOOP_CONF_PREFIX = "com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.";
 

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/test/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaProducerPropertyTest.java
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/test/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaProducerPropertyTest.java
@@ -22,6 +22,7 @@ import static com.expediagroup.apiary.extensions.events.metastore.kafka.messagin
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.BOOTSTRAP_SERVERS;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.BUFFER_MEMORY;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.CLIENT_ID;
+import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.COMPRESSION_TYPE;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.LINGER_MS;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.RETRIES;
@@ -40,7 +41,7 @@ public class KafkaProducerPropertyTest {
 
   @Test
   public void numberOfProperties() {
-    assertThat(KafkaProducerProperty.values().length).isEqualTo(10);
+    assertThat(KafkaProducerProperty.values().length).isEqualTo(11);
   }
 
   @Test
@@ -113,6 +114,13 @@ public class KafkaProducerPropertyTest {
     assertThat(SERDE_CLASS.unprefixedKey()).isEqualTo("serde.class");
     assertThat(SERDE_CLASS.key()).isEqualTo(prefixedKey("serde.class"));
     assertThat(SERDE_CLASS.defaultValue()).isEqualTo(JsonMetaStoreEventSerDe.class.getName());
+  }
+
+  @Test
+  public void compressionType() {
+    assertThat(COMPRESSION_TYPE.unprefixedKey()).isEqualTo("compression.type");
+    assertThat(COMPRESSION_TYPE.key()).isEqualTo(prefixedKey("compression.type"));
+    assertThat(COMPRESSION_TYPE.defaultValue()).isEqualTo("producer");
   }
 
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/apiary-extensions/blob/main/CONTRIBUTING.md
-->

### :pencil: Description
Adding `compression.type` [Kafka property](https://docs.confluent.io/platform/current/installation/configuration/broker-configs.html#compression-type) in `kafka-metastore-listener`.

### :link: Related Issues