### PR TITLE
Add max request size Kafka config in Metastore Event Listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 7.3.8 - 2023-08-02
+### Added
+- `max.request.size` [Kafka property](https://kafka.apache.org/documentation/#producerconfigs_max.request.size) in `kafka-metastore-listener`.
+
 ## 7.3.7 - 2023-07-19
 ### Added
-- `compression.type` [Kafka property](https://docs.confluent.io/platform/current/installation/configuration/broker-configs.html#compression-type) in `kafka-metastore-listener`.
+- `compression.type` [Kafka property](https://kafka.apache.org/documentation/#brokerconfigs_compression.type) in `kafka-metastore-listener`.
 
 ## 7.3.6 - 2022-11-14
 ### Fixed

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaMessageSender.java
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaMessageSender.java
@@ -27,6 +27,7 @@ import static com.expediagroup.apiary.extensions.events.metastore.kafka.messagin
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.COMPRESSION_TYPE;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.LINGER_MS;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION;
+import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.MAX_REQUEST_SIZE;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.RETRIES;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.TOPIC_NAME;
 
@@ -79,6 +80,7 @@ public class KafkaMessageSender {
     props.put(LINGER_MS.unprefixedKey(), longProperty(conf, LINGER_MS));
     props.put(BUFFER_MEMORY.unprefixedKey(), longProperty(conf, BUFFER_MEMORY));
     props.put(COMPRESSION_TYPE.unprefixedKey(), stringProperty(conf, COMPRESSION_TYPE));
+    props.put(MAX_REQUEST_SIZE.unprefixedKey(), intProperty(conf, MAX_REQUEST_SIZE));
     props.put("key.serializer", "org.apache.kafka.common.serialization.LongSerializer");
     props.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
     return props;

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaProducerProperty.java
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaProducerProperty.java
@@ -29,7 +29,8 @@ public enum KafkaProducerProperty implements Property {
   LINGER_MS("linger.ms", 1L),
   BUFFER_MEMORY("buffer.memory", 33554432L),
   SERDE_CLASS("serde.class", JsonMetaStoreEventSerDe.class.getName()),
-  COMPRESSION_TYPE("compression.type", "none");
+  COMPRESSION_TYPE("compression.type", "none"),
+  MAX_REQUEST_SIZE("max.request.size", 1048576);
 
   private static final String HADOOP_CONF_PREFIX = "com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.";
 

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/test/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaProducerPropertyTest.java
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/test/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaProducerPropertyTest.java
@@ -25,6 +25,7 @@ import static com.expediagroup.apiary.extensions.events.metastore.kafka.messagin
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.COMPRESSION_TYPE;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.LINGER_MS;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION;
+import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.MAX_REQUEST_SIZE;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.RETRIES;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.SERDE_CLASS;
 import static com.expediagroup.apiary.extensions.events.metastore.kafka.messaging.KafkaProducerProperty.TOPIC_NAME;
@@ -41,7 +42,7 @@ public class KafkaProducerPropertyTest {
 
   @Test
   public void numberOfProperties() {
-    assertThat(KafkaProducerProperty.values().length).isEqualTo(11);
+    assertThat(KafkaProducerProperty.values().length).isEqualTo(12);
   }
 
   @Test
@@ -121,6 +122,13 @@ public class KafkaProducerPropertyTest {
     assertThat(COMPRESSION_TYPE.unprefixedKey()).isEqualTo("compression.type");
     assertThat(COMPRESSION_TYPE.key()).isEqualTo(prefixedKey("compression.type"));
     assertThat(COMPRESSION_TYPE.defaultValue()).isEqualTo("none");
+  }
+
+  @Test
+  public void maxRequestSize() {
+    assertThat(MAX_REQUEST_SIZE.unprefixedKey()).isEqualTo("max.request.size");
+    assertThat(MAX_REQUEST_SIZE.key()).isEqualTo(prefixedKey("max.request.size"));
+    assertThat(MAX_REQUEST_SIZE.defaultValue()).isEqualTo(1048576);
   }
 
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/apiary-extensions/blob/main/CONTRIBUTING.md
-->

### :pencil: Description
Added `max.request.size` [Kafka property](https://kafka.apache.org/documentation/#producerconfigs_max.request.size) in `kafka-metastore-listener`.

### :link: Related Issues