### PR TITLE
Add sts dependency to apiary-receiver-sqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-
+## 7.3.10 - 2024-06-18
+### Added
+- Add `aws-java-sdk-sts` to enable IRSA authentication in `apiary-receiver-sqs`.
 
 ## 7.3.9 - 2024-06-03
 ### Added

--- a/apiary-metastore-events/sns-metastore-events/apiary-receivers/apiary-receiver-sqs/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-receivers/apiary-receiver-sqs/pom.xml
@@ -28,6 +28,11 @@
       <artifactId>aws-java-sdk-sqs</artifactId>
       <version>${aws.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sts</artifactId>
+      <version>${aws.version}</version>
+    </dependency>
 
     <!-- Google -->
     <dependency>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ X] Code is up-to-date with the `main` branch.
* [ X] You've successfully built and run the tests locally.
* [ X] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/apiary-extensions/blob/main/CONTRIBUTING.md
-->

### :pencil: Description
Add sts dependency in apiary-receiver-sqs to avoid assume role issues in AWS


### :link: Related Issues