### PR TITLE
BREAKING CHANGE:glue_sync skip archive by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 8.0.0 - 2024-08-27
+### Changed
+- `ApiaryGlueSync` override `skipArchive` to be `true` by default. Backward incompatible behavior that turns off table archiving by default. Allows for per table overrides if needed. If you don't rely on Glue table version it is safe to upgrade to this version of the glue listener without making changes.
+
 ## 7.3.11 - 2024-06-19
 ### Changed
 - Upgrade aws version from `1.11.520` to `1.12.276` in `apiary-receiver-sqs`.

--- a/apiary-metastore-events/apiary-hive-events/pom.xml
+++ b/apiary-metastore-events/apiary-hive-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-metastore-events-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-hive-events</artifactId>

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-integration-tests/pom.xml
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kafka-metastore-events-parent</artifactId>
     <groupId>com.expediagroup.apiary</groupId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kafka-metastore-integration-tests</artifactId>

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/pom.xml
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>kafka-metastore-events-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kafka-metastore-listener</artifactId>

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaMessageSender.java
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaMessageSender.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2020 Expedia, Inc.
+ * Copyright (C) 2018-2023 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaProducerProperty.java
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/main/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaProducerProperty.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2020 Expedia, Inc.
+ * Copyright (C) 2018-2023 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/test/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaProducerPropertyTest.java
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-listener/src/test/java/com/expediagroup/apiary/extensions/events/metastore/kafka/messaging/KafkaProducerPropertyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2020 Expedia, Inc.
+ * Copyright (C) 2018-2023 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/apiary-metastore-events/kafka-metastore-events/kafka-metastore-receiver/pom.xml
+++ b/apiary-metastore-events/kafka-metastore-events/kafka-metastore-receiver/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kafka-metastore-events-parent</artifactId>
     <groupId>com.expediagroup.apiary</groupId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kafka-metastore-receiver</artifactId>

--- a/apiary-metastore-events/kafka-metastore-events/pom.xml
+++ b/apiary-metastore-events/kafka-metastore-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-metastore-events-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kafka-metastore-events-parent</artifactId>

--- a/apiary-metastore-events/pom.xml
+++ b/apiary-metastore-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-events-parent</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/metastore-consumer-common/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/metastore-consumer-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-metastore-consumers-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>metastore-consumer-common</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>sns-metastore-events-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-consumers-parent</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/privileges-grantor/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/privileges-grantor/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-metastore-consumers-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-privileges-grantor-parent</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/privileges-grantor/privileges-grantor-core/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/privileges-grantor/privileges-grantor-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-privileges-grantor-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-privileges-grantor-core</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/privileges-grantor/privileges-grantor-lambda/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-consumers/privileges-grantor/privileges-grantor-lambda/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-privileges-grantor-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-privileges-grantor-lambda</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-metastore-listener/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-metastore-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>sns-metastore-events-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-listener</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-receivers/apiary-receiver-common/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-receivers/apiary-receiver-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-receivers-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-receiver-common</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-receivers/apiary-receiver-sqs/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-receivers/apiary-receiver-sqs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-receivers-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-receiver-sqs</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/apiary-receivers/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/apiary-receivers/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>sns-metastore-events-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-receivers-parent</artifactId>

--- a/apiary-metastore-events/sns-metastore-events/pom.xml
+++ b/apiary-metastore-events/sns-metastore-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-metastore-events-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>sns-metastore-events-parent</artifactId>

--- a/apiary-metastore-metrics/pom.xml
+++ b/apiary-metastore-metrics/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>apiary-extensions-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-metrics</artifactId>

--- a/hive-event-listeners/apiary-gluesync-listener/README.md
+++ b/hive-event-listeners/apiary-gluesync-listener/README.md
@@ -14,6 +14,11 @@ The GlueSync listener can be configured by setting the following System Environm
 |----|----|----|
 GLUE_PREFIX|No|Prefix added to Glue databases to handle database name collisions when synchronizing multiple metastores to the Glue catalog.
 
+## Table update SkipArchive
+[AWS default](https://docs.aws.amazon.com/glue/latest/webapi/API_UpdateTable.html#Glue-UpdateTable-request-SkipArchive) is to archive the table on every update. This especially with Iceberg tables can lead to a lot of table version of which you can only have a certain limit. To counter this we override this property and set skipArchive=true so do *not* make an archive of the table when updating. 
+If an archive is needed, this can be done per table by setting the Hive table property: 'apiary.gluesync.skipArchive=false'.
+
+
 # Legal
 This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
 

--- a/hive-event-listeners/apiary-gluesync-listener/pom.xml
+++ b/hive-event-listeners/apiary-gluesync-listener/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>hive-event-listeners-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-gluesync-listener</artifactId>

--- a/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/IcebergTableOperations.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/IcebergTableOperations.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2018-2022 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.expediagroup.apiary.extensions.gluesync.listener;
 
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;

--- a/hive-event-listeners/apiary-metastore-auth/pom.xml
+++ b/hive-event-listeners/apiary-metastore-auth/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>hive-event-listeners-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-metastore-auth</artifactId>

--- a/hive-event-listeners/apiary-ranger-metastore-plugin/pom.xml
+++ b/hive-event-listeners/apiary-ranger-metastore-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.expediagroup.apiary</groupId>
     <artifactId>hive-event-listeners-parent</artifactId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apiary-ranger-metastore-plugin</artifactId>

--- a/hive-event-listeners/pom.xml
+++ b/hive-event-listeners/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>apiary-extensions-parent</artifactId>
     <groupId>com.expediagroup.apiary</groupId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hive-event-listeners-parent</artifactId>

--- a/hive-hooks/pom.xml
+++ b/hive-hooks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>apiary-extensions-parent</artifactId>
     <groupId>com.expediagroup.apiary</groupId>
-    <version>7.3.12-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hive-hooks</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>com.expediagroup.apiary</groupId>
   <artifactId>apiary-extensions-parent</artifactId>
   <description>Various extensions to Apiary that provide additional, optional functionality</description>
-  <version>7.3.12-SNAPSHOT</version>
+  <version>8.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apiary Extensions Parent</name>
   <inceptionYear>2018</inceptionYear>


### PR DESCRIPTION
We've noticed that Iceberg tables can quickly generate a lot of table version in Glue this PR aims to disable table versioning by default.