### PR TITLE
GlueSyncListener - Fail silently and add metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 8.1.6 - 2025-05-16
+### Changed
+- Glue sync failures are now handled silently.
+- Metrics added to glue-sync-listener.
+
 ## 8.1.5 - 2025-05-13
 ### Changed
 - Improved performance when cleaning column comments in glue listener.

--- a/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/metrics/MetricConstants.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/metrics/MetricConstants.java
@@ -1,0 +1,13 @@
+package com.expediagroup.apiary.extensions.gluesync.listener.metrics;
+
+public class MetricConstants {
+
+  public static final String LISTENER_DATABASE_FAILURE = "glue_listener_database_failure";
+  public static final String LISTENER_DATABASE_SUCCESS = "glue_listener_database_success";
+  public static final String LISTENER_TABLE_FAILURE = "glue_listener_table_failure";
+  public static final String LISTENER_TABLE_SUCCESS = "glue_listener_table_success";
+  public static final String LISTENER_PARTITION_FAILURE = "glue_listener_partition_failure";
+  public static final String LISTENER_PARTITION_SUCCESS = "glue_listener_partition_success";
+
+  private MetricConstants() {}
+}

--- a/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/metrics/MetricService.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/metrics/MetricService.java
@@ -1,0 +1,25 @@
+package com.expediagroup.apiary.extensions.gluesync.listener.metrics;
+
+import java.util.Optional;
+
+import org.apache.hadoop.hive.common.metrics.common.Metrics;
+import org.apache.hadoop.hive.common.metrics.common.MetricsFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MetricService {
+
+  private static final Logger log = LoggerFactory.getLogger(MetricService.class);
+
+  public Optional<Long> incrementCounter(String name) {
+    try {
+      Metrics metrics = MetricsFactory.getInstance();
+      if (metrics != null) {
+        return Optional.of(metrics.incrementCounter(name));
+      }
+    } catch (Exception e) {
+      log.warn("Unable to increment counter {}", name, e);
+    }
+    return Optional.empty();
+  }
+}


### PR DESCRIPTION
We discovered when gluesync fails, the HMS operation succeeds returning a glue exception to the client (this is not what we exepcted before).

Based on this, it makes sense not to return an exception to the client if the HMS operation went through.