### PR TITLE
Add classification support for parquet, avro and orc table formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 8.1.9 - 2025-06-04
+### Changed
+- Add classification support for `parquet`, `avro` and `orc` table formats in `glue-event-listener`.
+
 ## 8.1.8 - 2025-05-22
 ### Changed
 - Update metrics to use micrometer instead of Codahale in glue-event-listener.

--- a/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/service/HiveToGlueTransformer.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/service/HiveToGlueTransformer.java
@@ -185,14 +185,15 @@ public class HiveToGlueTransformer {
     return null;
   }
 
+  /**
+   * Add classification parameter if not already present to help AWS Glue identify the table format.
+   */
   private Map<String, String> addClassification(Map<String, String> params, String inputFormat) {
     if (params == null) {
       params = new HashMap<>();
     }
     if (!params.containsKey("classification")) {
-      if (isIcebergPredicate.test(params)) {
-        params.put("classification", params.getOrDefault("write.format.default", "parquet"));
-      } else {
+      if (!isIcebergPredicate.test(params)) { // If it is Hive (non-Iceberg)
         String classification = getHiveClassification(inputFormat);
         if (classification != null) {
           params.put("classification", classification);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/apiary-extensions/blob/main/CONTRIBUTING.md
-->

### :pencil: Description

Hive StorageDescriptor Field | File Format (Classification)
-- | --
InputFormat |  
↳ org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat | avro
↳ org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat | parquet
↳ org.apache.hadoop.hive.ql.io.orc.OrcInputFormat | orc


For Iceberg 
https://iceberg.apache.org/docs/1.5.1/configuration/#write-properties
### :link: Related Issues