### PR TITLE
Fix Glue classification NPE when SerDes are not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 8.1.13 - 2025-09-04
+### Changed
+- Fixed Glue Classification NPE exception when SerDes library are not found in Hive table properties.
+
 ## 8.1.12 - 2025-08-25
 ### Added
 - Table and partition locations s3 prefixes are changed to `s3://` because platforms like Databricks and AWS Cleanrooms,

--- a/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/service/HiveToGlueTransformer.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/service/HiveToGlueTransformer.java
@@ -206,8 +206,9 @@ public class HiveToGlueTransformer {
   }
 
   private String getHiveClassification(String inputFormat) {
-    String lower = inputFormat.toLowerCase();
+    if (inputFormat == null) {return null;}
 
+    String lower = inputFormat.toLowerCase();
     if (lower.contains("parquet")) {return "parquet";}
     if (lower.contains("avro")) {return "avro";}
     if (lower.contains("orc")) {return "orc";}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/ExpediaGroup/apiary-extensions/blob/main/CONTRIBUTING.md
-->

### :pencil: Description
- Looks like SerDes are not required for all Hive tables, we found some JDBC tables without it and threw a NPE.