### PR TITLE
fix: use equalsIgnoreCase in isTableRename to match HMS behaviour 

### DIFF
--- a/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/ApiaryGlueSync.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/ApiaryGlueSync.java
@@ -302,7 +302,7 @@ public class ApiaryGlueSync extends MetaStoreEventListener {
   }
 
   private boolean isTableRename(Table oldTable, Table newTable) {
-    return !oldTable.getTableName().equals(newTable.getTableName());
+    return !oldTable.getTableName().equalsIgnoreCase(newTable.getTableName());
   }
 
   @Override

--- a/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/ApiaryGlueSyncTest.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/ApiaryGlueSyncTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -497,6 +498,29 @@ public class ApiaryGlueSyncTest {
     assertThat(createTableRequest.getTableInput().getLastAccessTime(), is(new Date(lastAccessTime)));
     assertThat(toList(createTableRequest.getTableInput().getPartitionKeys()), is(asList(partNames)));
     assertThat(toList(createTableRequest.getTableInput().getStorageDescriptor().getColumns()), is(asList(colNames)));
+  }
+
+  @Test
+  public void onAlterHiveTable_CaseOnlyRenameSkipsRenameOperation() throws MetaException {
+    AlterTableEvent event = mock(AlterTableEvent.class);
+    when(event.getStatus()).thenReturn(true);
+
+    Table oldTable = simpleHiveTable(simpleSchema(), simplePartitioning());
+    oldTable.setTableName("some_table");
+    when(event.getOldTable()).thenReturn(oldTable);
+
+    Table newTable = simpleHiveTable(simpleSchema(), simplePartitioning());
+    newTable.setTableName("Some_Table");
+    when(event.getNewTable()).thenReturn(newTable);
+
+    glueSync.onAlterTable(event);
+
+    // case-only difference must not trigger the rename path (create + copy + delete)
+    verify(glueClient, never()).createTable(any());
+    verify(glueClient, never()).deleteTable(any());
+    verify(glueClient, never()).batchCreatePartition(any());
+    // normal update path must be followed instead
+    verify(glueClient).updateTable(any());
   }
 
   @Test


### PR DESCRIPTION
 ## Problem                                                                                                                                                                        
                                                                                                                                                                                    
  `ApiaryGlueSync.isTableRename()` used `String.equals()` to compare old and new                                                                                                    
  table names. This caused a case-only name change (e.g.                                                                                                                            
  `foo_bar_baz` → `Foo_Bar_Baz`) to be                                                                                                          
  treated as a genuine rename, triggering `doRenameOperation` and an                                                                                                                
  `AlreadyExistsException` from Glue on every replay of the event.                                                                                                                  
                                                                                                                                                                                    
  ### Why this happens                                                                                                                                                              
                                                                                                                                                                                    
  When a client calls `alter_table` on HMS with a new `Table` object whose                                                                                                          
  `tableName` differs from the stored name only in case, HMS does **not** treat                                                                                                     
  it as a rename. `HiveAlterHandler.alterTable()` lowercases the old table name                                                                                                     
  parameter (lines 135–136) and then uses `equalsIgnoreCase` for the rename                                                                                                         
  check (lines 138–143):                                                                                                                                                            
                                                                                                                                                                                    
  ```java                                                                                                                                                                           
  // HiveAlterHandler.java (branch-2.3, lines 135–143)                                                                                                                              
  name = name.toLowerCase();                                                                                                                                                        
  dbname = dbname.toLowerCase();                                                                                                                                                    
                                                                                                                                                                                    
  if (!newt.getTableName().equalsIgnoreCase(name)                                                                                                                                   
      || !newt.getDbName().equalsIgnoreCase(dbname)) {                                                                                                                              
    if (msdb.getTable(newt.getDbName(), newt.getTableName()) != null) {                                                                                                             
      throw new InvalidOperationException(...)                                                                                                                                      
    }                                                                                                                                                                               
    rename = true;                                                                                                                                                                  
  }                                                                                                                                                                                 
           
```
                                                                                                                                                                         
  HMS completes the alter_table as a metadata update without renaming. The                                                                                                          
  AlterTableEvent is then fired after alterHandler.alterTable() returns,                                                                                                            
  with the original newt object unchanged — so newt.getTableName() carries                                                                                                          
  the mixed-case name as provided by the caller.                                                                                                                                    
                                                                                                                                                                                    
  ApiaryGlueSync received this event and compared names with equals(),                                                                                                              
  disagreeing with HMS's own equalsIgnoreCase check. It entered                                                                                                                     
  doRenameOperation, called GlueTableService.create() with the mixed-case                                                                                                           
  name, and got AlreadyExistsException because Glue is also case-insensitive                                                                                                        
  and the lowercase table already existed.                 

 ## Fix                                                                                                                                                                               
                                                                                                                                                                                    
  Change isTableRename() to use equalsIgnoreCase(), aligning it with HMS's                                                                                                          
  own rename-detection logic. A case-only difference is now treated as a regular                                                                                                    
  metadata update (falls through to updateTable) rather than a rename.                                                                                                              
                                                                                                                                                                                    
  This is a defensive fix in GlueSync. The root cause — egdl-hive-agent                                                                                                             
  constructing Table objects with mixed-case names derived from Avro record                                                                                                         
  names — should be addressed separately in that repo.                                                                                                                              
                                                                                                                                                                                    
  ## Test plan                                                                                                                                                                         
                                                                                                                                                                                    
  - New test onAlterHiveTable_CaseOnlyRenameSkipsRenameOperation verifies                                                                                                           
  that create, batchCreatePartition, and deleteTable are never called                                                                                                               
  when old and new table names differ only by case, and that updateTable                                                                                                            
  is called instead.                                                                                                                                                                
  - Existing rename tests (onAlterHiveTable_RenameTable,                                                                                                                            
  onAlterHiveTable_RenameOperationFailureIsMetered,                                                                                                                                 
  onAlterIcebergTable_RenameTableSkipsRenameOperation) all continue to pass.                                                                                                        
  - mvn -pl hive-event-listeners/apiary-gluesync-listener -am test — 110 tests, 0 failures.           