### PR TITLE
feat: populate Glue table description from HMS comment parameter

### DIFF
--- a/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/service/GlueMetadataStringCleaner.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/service/GlueMetadataStringCleaner.java
@@ -29,6 +29,9 @@ import com.amazonaws.services.glue.model.TableInput;
  */
 public class GlueMetadataStringCleaner {
 
+  private static final int MAX_COLUMN_COMMENT_LENGTH = 254;
+  private static final int MAX_DESCRIPTION_LENGTH = 2048;
+
   public TableInput cleanTable(TableInput input) {
     // Clean SerDes
     cleanColumns(input.getStorageDescriptor().getColumns());
@@ -56,20 +59,16 @@ public class GlueMetadataStringCleaner {
    * </ul>
    */
   private String cleanDescription(String description) {
-    return truncateToMaxAllowedChars(removeNonUnicodeChars(description), 2048);
+    return truncateToMaxAllowedChars(removeNonUnicodeChars(description), MAX_DESCRIPTION_LENGTH);
   }
 
   private void cleanColumns(List<Column> columns) {
     for (Column column : columns) {
-      column.setComment(this.truncateToMaxAllowedChars(this.removeNonUnicodeChars(column.getComment())));
+      column.setComment(this.truncateToMaxAllowedChars(this.removeNonUnicodeChars(column.getComment()), MAX_COLUMN_COMMENT_LENGTH));
     }
   }
 
-  public String truncateToMaxAllowedChars(String input) {
-    return truncateToMaxAllowedChars(input, 254);
-  }
-
-  private String truncateToMaxAllowedChars(String input, int maxLength) {
+  public String truncateToMaxAllowedChars(String input, int maxLength) {
     if (input == null) {
       return null;
     }

--- a/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/service/GlueMetadataStringCleaner.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/service/GlueMetadataStringCleaner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2025 Expedia, Inc.
+ * Copyright (C) 2018-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,8 @@ public class GlueMetadataStringCleaner {
     cleanColumns(input.getStorageDescriptor().getColumns());
     // Clean Partition Keys
     cleanColumns(input.getPartitionKeys());
+    // Clean Description
+    input.setDescription(removeNonUnicodeChars(input.getDescription()));
     return input;
   }
 

--- a/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/service/GlueMetadataStringCleaner.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/service/GlueMetadataStringCleaner.java
@@ -34,7 +34,6 @@ public class GlueMetadataStringCleaner {
     cleanColumns(input.getStorageDescriptor().getColumns());
     // Clean Partition Keys
     cleanColumns(input.getPartitionKeys());
-    // Clean Description
     input.setDescription(cleanDescription(input.getDescription()));
     return input;
   }
@@ -49,6 +48,13 @@ public class GlueMetadataStringCleaner {
     return input;
   }
 
+  /**
+   * Cleans a Glue TableInput description to satisfy API constraints:
+   * <ul>
+   *   <li>Unicode characters only</li>
+   *   <li>Maximum 2048 characters</li>
+   * </ul>
+   */
   private String cleanDescription(String description) {
     return truncateToMaxAllowedChars(removeNonUnicodeChars(description), 2048);
   }

--- a/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/service/GlueMetadataStringCleaner.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/service/GlueMetadataStringCleaner.java
@@ -35,7 +35,7 @@ public class GlueMetadataStringCleaner {
     // Clean Partition Keys
     cleanColumns(input.getPartitionKeys());
     // Clean Description
-    input.setDescription(removeNonUnicodeChars(input.getDescription()));
+    input.setDescription(cleanDescription(input.getDescription()));
     return input;
   }
 
@@ -49,6 +49,10 @@ public class GlueMetadataStringCleaner {
     return input;
   }
 
+  private String cleanDescription(String description) {
+    return truncateToMaxAllowedChars(removeNonUnicodeChars(description), 2048);
+  }
+
   private void cleanColumns(List<Column> columns) {
     for (Column column : columns) {
       column.setComment(this.truncateToMaxAllowedChars(this.removeNonUnicodeChars(column.getComment())));
@@ -56,13 +60,14 @@ public class GlueMetadataStringCleaner {
   }
 
   public String truncateToMaxAllowedChars(String input) {
+    return truncateToMaxAllowedChars(input, 254);
+  }
+
+  private String truncateToMaxAllowedChars(String input, int maxLength) {
     if (input == null) {
       return null;
     }
-    if (input.length() > 254) {
-      return input.substring(0, 254);
-    }
-    return input;
+    return input.length() > maxLength ? input.substring(0, maxLength) : input;
   }
 
   public String removeNonUnicodeChars(String input) {

--- a/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/service/HiveToGluePartitionComparator.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/service/HiveToGluePartitionComparator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2025 Expedia, Inc.
+ * Copyright (C) 2018-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.expediagroup.apiary.extensions.gluesync.listener.service;
 
 import java.util.*;
@@ -146,7 +145,7 @@ public class HiveToGluePartitionComparator {
         return false;
       // Clean Hive comment before comparing to cleaned Glue comment
       String cleanedHiveComment = cleaner.removeNonUnicodeChars(h.getComment());
-      cleanedHiveComment = cleaner.truncateToMaxAllowedChars(cleanedHiveComment);
+      cleanedHiveComment = cleaner.truncateToMaxAllowedChars(cleanedHiveComment, 254);
       if (!Objects.equals(cleanedHiveComment, g.getComment()))
         return false;
     }

--- a/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/service/HiveToGlueTransformer.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/main/java/com/expediagroup/apiary/extensions/gluesync/listener/service/HiveToGlueTransformer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2025 Expedia, Inc.
+ * Copyright (C) 2018-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,11 +93,15 @@ public class HiveToGlueTransformer {
         .withSortColumns(sortOrders)
         .withStoredAsSubDirectories(storageDescriptor.isStoredAsSubDirectories());
 
+    Map<String, String> tableParams = table.getParameters();
+    String description = (tableParams != null) ? tableParams.get("comment") : null;
+
     return new TableInput()
         .withName(table.getTableName())
+        .withDescription(description)
         .withLastAccessTime(date)
         .withOwner(table.getOwner())
-        .withParameters(addClassification(table.getParameters(), storageDescriptor.getInputFormat()))
+        .withParameters(addClassification(tableParams, storageDescriptor.getInputFormat()))
         .withPartitionKeys(partitionKeys)
         .withRetention(table.getRetention())
         .withStorageDescriptor(sd)

--- a/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/GlueMetadataStringCleanerTest.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/GlueMetadataStringCleanerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2025 Expedia, Inc.
+ * Copyright (C) 2018-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package com.expediagroup.apiary.extensions.gluesync.listener;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
@@ -62,6 +64,29 @@ public class GlueMetadataStringCleanerTest {
     Column partitionColumn = result.getPartitionKeys().get(0);
     assertTrue(partitionColumn.getComment().length() == 254);
     assertTrue(partitionColumn.getComment().startsWith("A"));
+  }
+
+  @Test
+  public void testTableInputDescriptionNonUnicodeCharsRemoved() {
+    TableInput tableInput = new TableInput();
+    tableInput.setStorageDescriptor(new StorageDescriptor().withColumns(Collections.emptyList()));
+    tableInput.setPartitionKeys(Collections.emptyList());
+    tableInput.setDescription("\uD999valid description");
+
+    TableInput result = glueMetadataStringCleaner.cleanTable(tableInput);
+
+    assertEquals("valid description", result.getDescription());
+  }
+
+  @Test
+  public void testTableInputDescriptionNullUnchanged() {
+    TableInput tableInput = new TableInput();
+    tableInput.setStorageDescriptor(new StorageDescriptor().withColumns(Collections.emptyList()));
+    tableInput.setPartitionKeys(Collections.emptyList());
+
+    TableInput result = glueMetadataStringCleaner.cleanTable(tableInput);
+
+    assertNull(result.getDescription());
   }
 
   @Test

--- a/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/GlueMetadataStringCleanerTest.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/GlueMetadataStringCleanerTest.java
@@ -79,6 +79,18 @@ public class GlueMetadataStringCleanerTest {
   }
 
   @Test
+  public void testTableInputDescriptionTruncatedTo2048Chars() {
+    TableInput tableInput = new TableInput();
+    tableInput.setStorageDescriptor(new StorageDescriptor().withColumns(Collections.emptyList()));
+    tableInput.setPartitionKeys(Collections.emptyList());
+    tableInput.setDescription("A".repeat(3000));
+
+    TableInput result = glueMetadataStringCleaner.cleanTable(tableInput);
+
+    assertEquals(2048, result.getDescription().length());
+  }
+
+  @Test
   public void testTableInputDescriptionNullUnchanged() {
     TableInput tableInput = new TableInput();
     tableInput.setStorageDescriptor(new StorageDescriptor().withColumns(Collections.emptyList()));

--- a/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/GlueMetadataStringCleanerTest.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/GlueMetadataStringCleanerTest.java
@@ -83,7 +83,7 @@ public class GlueMetadataStringCleanerTest {
     TableInput tableInput = new TableInput();
     tableInput.setStorageDescriptor(new StorageDescriptor().withColumns(Collections.emptyList()));
     tableInput.setPartitionKeys(Collections.emptyList());
-    tableInput.setDescription("A".repeat(3000));
+    tableInput.setDescription(generateCharString(3000));
 
     TableInput result = glueMetadataStringCleaner.cleanTable(tableInput);
 
@@ -123,7 +123,7 @@ public class GlueMetadataStringCleanerTest {
 
   private String generateCharString(int length) {
     StringBuilder sb = new StringBuilder(length);
-    for (int i = 0; i < 300; i++) {
+    for (int i = 0; i < length; i++) {
       sb.append("A");
     }
     return sb.toString();

--- a/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/service/HiveToGluePartitionComparatorTest.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/service/HiveToGluePartitionComparatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2025 Expedia, Inc.
+ * Copyright (C) 2018-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,7 +135,7 @@ public class HiveToGluePartitionComparatorTest {
           c.setName(fs.getName());
           c.setType(fs.getType());
           String cleanedComment = cleaner.removeNonUnicodeChars(fs.getComment());
-          cleanedComment = cleaner.truncateToMaxAllowedChars(cleanedComment);
+          cleanedComment = cleaner.truncateToMaxAllowedChars(cleanedComment, 254);
           c.setComment(cleanedComment);
           cols.add(c);
         }

--- a/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/service/HiveToGlueTransformerTest.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/service/HiveToGlueTransformerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2025 Expedia, Inc.
+ * Copyright (C) 2018-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package com.expediagroup.apiary.extensions.gluesync.listener.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,9 +28,11 @@ import java.util.Map;
 
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.Table;
 import org.junit.Test;
 
 import com.amazonaws.services.glue.model.PartitionInput;
+import com.amazonaws.services.glue.model.TableInput;
 
 public class HiveToGlueTransformerTest {
   private final HiveToGlueTransformer transformer = new HiveToGlueTransformer(null);
@@ -101,6 +104,57 @@ public class HiveToGlueTransformerTest {
     partition.getSd().setLocation("s3a://test-bucket/path"); // Test normalization
 
     return partition;
+  }
+
+  @Test
+  public void testTransformTablePopulatesDescriptionFromCommentParam() {
+    Table table = createMinimalHiveTable();
+    table.getParameters().put("comment", "my table description");
+
+    TableInput result = transformer.transformTable(table);
+
+    assertEquals("my table description", result.getDescription());
+  }
+
+  @Test
+  public void testTransformTableDescriptionIsNullWhenNoCommentParam() {
+    Table table = createMinimalHiveTable();
+
+    TableInput result = transformer.transformTable(table);
+
+    assertNull(result.getDescription());
+  }
+
+  private Table createMinimalHiveTable() {
+    Table table = new Table();
+    table.setTableName("test_table");
+    table.setDbName("test_db");
+    table.setOwner("test_owner");
+    table.setTableType("EXTERNAL_TABLE");
+    table.setParameters(new HashMap<>());
+
+    org.apache.hadoop.hive.metastore.api.StorageDescriptor sd = new org.apache.hadoop.hive.metastore.api.StorageDescriptor();
+    sd.setCols(Collections.emptyList());
+    sd.setBucketCols(Collections.emptyList());
+    sd.setCompressed(false);
+    sd.setInputFormat("org.apache.hadoop.mapred.TextInputFormat");
+    sd.setLocation("s3://test-bucket/path");
+    sd.setNumBuckets(0);
+    sd.setOutputFormat("org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat");
+    sd.setParameters(Collections.emptyMap());
+
+    org.apache.hadoop.hive.metastore.api.SerDeInfo serdeInfo = new org.apache.hadoop.hive.metastore.api.SerDeInfo();
+    serdeInfo.setName("test-serde");
+    serdeInfo.setSerializationLib("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe");
+    serdeInfo.setParameters(Collections.emptyMap());
+    sd.setSerdeInfo(serdeInfo);
+
+    sd.setSortCols(Collections.emptyList());
+    sd.setStoredAsSubDirectories(false);
+    table.setSd(sd);
+    table.setPartitionKeys(Collections.emptyList());
+
+    return table;
   }
 
   /**

--- a/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/service/HiveToGlueTransformerTest.java
+++ b/hive-event-listeners/apiary-gluesync-listener/src/test/java/com/expediagroup/apiary/extensions/gluesync/listener/service/HiveToGlueTransformerTest.java
@@ -125,6 +125,16 @@ public class HiveToGlueTransformerTest {
     assertNull(result.getDescription());
   }
 
+  @Test
+  public void testTransformTableDescriptionIsNullWhenParamsExistButNoComment() {
+    Table table = createMinimalHiveTable();
+    table.getParameters().put("other.param", "some value");
+
+    TableInput result = transformer.transformTable(table);
+
+    assertNull(result.getDescription());
+  }
+
   private Table createMinimalHiveTable() {
     Table table = new Table();
     table.setTableName("test_table");


### PR DESCRIPTION
## Summary                                                                                                                                                                        
                                                                                                                                                                                    
- Populates the Glue `TableInput.description` field from the HMS `comment` TBLPROPERTY during sync, making table documentation visible in the AWS Glue Data Catalog UI            
- Consistent with existing behaviour for databases, which already map `Database.description` to `DatabaseInput.description`                                                       
- Extends `GlueMetadataStringCleaner.cleanTable()` to sanitise the description field so the `ValidationException` retry path cannot fail on a non-Unicode table comment           
                                                                                                                                                                                    
## Notes                                                                                                                                                                          
                                                                                                                                                                                    
The `comment` value will appear in both `description` and `parameters["comment"]` on the Glue table — Glue treats these as separate fields and the redundancy is harmless.        
                                                                                                                                                                                    
## Test plan                                                                                                                                                                      
                                                                                                                                                                                    
- [ ] `HiveToGlueTransformerTest` — table with `comment` param maps to `TableInput.description`; table without `comment` param produces `null` description                        
- [ ] `GlueMetadataStringCleanerTest` — non-Unicode chars stripped from description in retry path; `null` description handled safely                                              
- [ ] Full module test suite passes (`mvn test -pl hive-event-listeners/apiary-gluesync-listener`)                                                                                
                                                                                                                                                                                    
🤖 Generated with [Claude Code](https://claude.com/claude-code)             